### PR TITLE
Fixed bugs in driver and ADT extension

### DIFF
--- a/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -39,7 +39,9 @@ IOVal<Integer> ::= args::[String] ioIn::IO
 
   local writePP :: IO = writeFile(ppFileName, show(80, ast.pp), text.io);
 
-  return if !isF.iovalue then
+  return if null(args) then
+    ioval(print("Usage: [ableC invocation] [file name] [c preprocessor arguments]\n", ioIn), 5)
+  else if !isF.iovalue then
     ioval(print("File \"" ++ fileName ++ "\" not found.\n", isF.io), 1)
   else if mkCppFile.iovalue != 0 then
     ioval(print("CPP call failed.\n", mkCppFile.io), 3)

--- a/extensions/algebraic-data-types/edu.umn.cs.melt.exts.ableC.adt/abstractsyntax/Match.sv
+++ b/extensions/algebraic-data-types/edu.umn.cs.melt.exts.ableC.adt/abstractsyntax/Match.sv
@@ -11,7 +11,10 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 abstract production matchStmt
 e::Expr ::= scrutinee::Expr cs::StmtClauses
 {
-  e.errors := scrutinee.errors ++ cs.errors;
+  e.errors := case scrutinee.typerep of
+              | pointerType(_,adtTagType(_, adtRefId, _)) -> []
+              | _ -> [err(scrutinee.location, "scrutinee expression does not have adt pointer type (got " ++ showType(scrutinee.typerep) ++ ")")]
+              end ++ scrutinee.errors ++ cs.errors;
 
   local scrutineeTypeInfo :: Pair<String [ Pair<String [Type]> ]>    
     = case scrutinee.typerep of


### PR DESCRIPTION
The driver now prints usage information and exits when no arguments are provided.  

Matching on a non-ADT-pointer in the ADT extension gives an error message.  