### PR TITLE
Added operator overloading to ableC

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/ExprBinOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/ExprBinOps.sv
@@ -2,12 +2,17 @@
 autocopy attribute lop :: Decorated Expr;
 autocopy attribute rop :: Decorated Expr;
 
-nonterminal BinOp with location, lop, rop, pp, typerep, errors;
+nonterminal BinOp with location, lop, rop, opName, pp, typerep, errors;
 
 aspect default production
 top::BinOp ::=
 {
   top.errors := []; -- TODO REMOVE
+  top.opName =
+    case top.pp of
+      text(opName) -> opName
+    | _ -> error("Op pp isn't simple text, opName must be overridden manually")
+    end;
 }
 
 --------------------------------------------------------------------------------

--- a/edu.umn.cs.melt.ableC/abstractsyntax/ExprConstants.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/ExprConstants.sv
@@ -35,7 +35,7 @@ top::Expr ::= num::String  c::CharPrefix
   top.globalDecls := [];
   top.defs = [];
   top.freeVariables = [];
-  top.typerep = builtinType([], signedType(intType())); -- TODO: no idea
+  top.typerep = builtinType([], signedType(charType())); -- TODO: no idea
 }
 
 nonterminal NumericConstant with location, pp, errors, env, constanttyperep;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/ExprUnaryOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/ExprUnaryOps.sv
@@ -1,7 +1,8 @@
 
-nonterminal UnaryOp with location, op, pp, preExpr, noLvalueConversion, typerep, errors;
+nonterminal UnaryOp with location, op, opName, pp, preExpr, noLvalueConversion, typerep, errors;
 
 autocopy attribute op :: Decorated Expr;
+synthesized attribute opName :: String;
 synthesized attribute preExpr :: Boolean;
 synthesized attribute noLvalueConversion :: Boolean;
 
@@ -9,11 +10,17 @@ aspect default production
 top::UnaryOp ::=
 {
   top.errors := []; -- TODO REMOVE
+  top.opName =
+    case top.pp of
+      text(opName) -> opName
+    | _ -> error("Op pp isn't simple text, opName must be overridden manually")
+    end;
 }
 
 abstract production preIncOp
 top::UnaryOp ::=
 {
+  top.opName = "pre++";
   top.pp = text("++");
   top.preExpr = true;
   top.noLvalueConversion = false;
@@ -22,6 +29,7 @@ top::UnaryOp ::=
 abstract production preDecOp
 top::UnaryOp ::= 
 {
+  top.opName = "pre--";
   top.pp = text("--");
   top.preExpr = true;
   top.noLvalueConversion = true;
@@ -30,6 +38,7 @@ top::UnaryOp ::=
 abstract production postIncOp
 top::UnaryOp ::= 
 {
+  top.opName = "post++";
   top.pp = text("++");
   top.preExpr = false;
   top.noLvalueConversion = true;
@@ -38,6 +47,7 @@ top::UnaryOp ::=
 abstract production postDecOp
 top::UnaryOp ::= 
 {
+  top.opName = "post--";
   top.pp = text("--");
   top.preExpr = false;
   top.noLvalueConversion = true;
@@ -123,8 +133,6 @@ top::UnaryOp ::=
   top.noLvalueConversion = false;
   top.typerep = top.op.typerep.defaultLvalueConversion.integerPromotions;
 }
-
-
 
 autocopy attribute typeop :: Type;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/OpOverload.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/OpOverload.sv
@@ -1,0 +1,393 @@
+grammar edu:umn:cs:melt:ableC:abstractsyntax;
+
+inherited attribute otherType::Type occurs on Type;
+
+synthesized attribute preIncProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute preDecProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute postIncProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute postDecProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryAndProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryStarProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryPlusProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryMinusProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryTildaProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute unaryBangProd::Maybe<(Expr ::= Expr Location)> occurs on Type;
+synthesized attribute lAssignProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignStarProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignSlashProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignPercentProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignPlusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignMinusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignDoubleLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignDoubleGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignSingleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignSingleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lAssignCaratProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryDoubleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryDoubleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinarySingleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinarySingleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryCaratProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryDoubleLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryDoubleGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryEqProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryNeqProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryGteProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryLteProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryPlusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryMinusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryStarProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinarySlashProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute lBinaryPercentProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignStarProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignSlashProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignPercentProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignPlusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignMinusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignDoubleLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignDoubleGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignSingleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignSingleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rAssignCaratProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryDoubleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryDoubleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinarySingleAndProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinarySingleOrProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryCaratProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryDoubleLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryDoubleGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryEqProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryNeqProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryGtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryLtProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryGteProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryLteProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryPlusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryMinusProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryStarProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinarySlashProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+synthesized attribute rBinaryPercentProd::Maybe<(Expr ::= Expr Expr Location)> occurs on Type;
+
+aspect default production
+top::Type ::= 
+{
+  top.preIncProd = nothing();
+  top.preDecProd = nothing();
+  top.postIncProd = nothing();
+  top.postDecProd = nothing();
+  top.unaryAndProd = nothing();
+  top.unaryStarProd = nothing();
+  top.unaryPlusProd = nothing();
+  top.unaryMinusProd = nothing();
+  top.unaryTildaProd = nothing();
+  top.unaryBangProd = nothing();
+  top.lAssignProd = nothing();
+  top.lAssignStarProd = nothing();
+  top.lAssignSlashProd = nothing();
+  top.lAssignPercentProd = nothing();
+  top.lAssignPlusProd = nothing();
+  top.lAssignMinusProd = nothing();
+  top.lAssignDoubleLtProd = nothing();
+  top.lAssignDoubleGtProd = nothing();
+  top.lAssignSingleAndProd = nothing();
+  top.lAssignSingleOrProd = nothing();
+  top.lAssignCaratProd = nothing();
+  top.lBinaryDoubleAndProd = nothing();
+  top.lBinaryDoubleOrProd = nothing();
+  top.lBinarySingleAndProd = nothing();
+  top.lBinarySingleOrProd = nothing();
+  top.lBinaryCaratProd = nothing();
+  top.lBinaryDoubleLtProd = nothing();
+  top.lBinaryDoubleGtProd = nothing();
+  top.lBinaryEqProd = nothing();
+  top.lBinaryNeqProd = nothing();
+  top.lBinaryGtProd = nothing();
+  top.lBinaryLtProd = nothing();
+  top.lBinaryGteProd = nothing();
+  top.lBinaryLteProd = nothing();
+  top.lBinaryPlusProd = nothing();
+  top.lBinaryMinusProd = nothing();
+  top.lBinaryStarProd = nothing();
+  top.lBinarySlashProd = nothing();
+  top.lBinaryPercentProd = nothing();
+  top.rAssignProd = nothing();
+  top.rAssignStarProd = nothing();
+  top.rAssignSlashProd = nothing();
+  top.rAssignPercentProd = nothing();
+  top.rAssignPlusProd = nothing();
+  top.rAssignMinusProd = nothing();
+  top.rAssignDoubleLtProd = nothing();
+  top.rAssignDoubleGtProd = nothing();
+  top.rAssignSingleAndProd = nothing();
+  top.rAssignSingleOrProd = nothing();
+  top.rAssignCaratProd = nothing();
+  top.rBinaryDoubleAndProd = nothing();
+  top.rBinaryDoubleOrProd = nothing();
+  top.rBinarySingleAndProd = nothing();
+  top.rBinarySingleOrProd = nothing();
+  top.rBinaryCaratProd = nothing();
+  top.rBinaryDoubleLtProd = nothing();
+  top.rBinaryDoubleGtProd = nothing();
+  top.rBinaryEqProd = nothing();
+  top.rBinaryNeqProd = nothing();
+  top.rBinaryGtProd = nothing();
+  top.rBinaryLtProd = nothing();
+  top.rBinaryGteProd = nothing();
+  top.rBinaryLteProd = nothing();
+  top.rBinaryPlusProd = nothing();
+  top.rBinaryMinusProd = nothing();
+  top.rBinaryStarProd = nothing();
+  top.rBinarySlashProd = nothing();
+  top.rBinaryPercentProd = nothing();
+}
+
+function getUnaryOverload
+(Expr ::= Expr Location) ::= op::UnaryOp t::Type
+{
+  return
+    case op.opName of
+      "pre++" -> convertUnaryMaybeProd(op, t.preIncProd)
+    | "pre--" -> convertUnaryMaybeProd(op, t.preDecProd)
+    | "post++" -> convertUnaryMaybeProd(op, t.postIncProd)
+    | "post--" -> convertUnaryMaybeProd(op, t.postDecProd)
+    | "&" -> convertUnaryMaybeProd(op, t.unaryAndProd)
+    | "*" -> convertUnaryMaybeProd(op, t.unaryStarProd)
+    | "+" -> convertUnaryMaybeProd(op, t.unaryPlusProd)
+    | "-" -> convertUnaryMaybeProd(op, t.unaryMinusProd)
+    | "~" -> convertUnaryMaybeProd(op, t.unaryTildaProd)
+    | "!" -> convertUnaryMaybeProd(op, t.unaryBangProd)
+    | _ -> unaryOpExprDefault(op, _, location=_) -- Misc. ops such as GCC extensions not overloaded
+    end;
+}
+
+function convertUnaryMaybeProd
+(Expr ::= Expr Location) ::= op::UnaryOp prod::Maybe<(Expr ::= Expr Location)>
+{
+  return
+    if prod.isJust
+    then prod.fromJust
+    else unaryOpExprDefault(op, _, location=_);
+}
+
+function getBinaryOverload
+(Expr ::= Expr Expr Location) ::= env::Decorated Env returnType::Maybe<Type> l::Type op::BinOp r::Type
+{
+  local prod::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, op.opName, r);
+  local assignProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, "=", r);
+  local assignOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, substitute("=", "", op.opName), r);
+  local eqOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, "==", r);
+  local gtOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, ">", r);
+  local ltOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, "<", r);
+  local gteOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, ">=", r);
+  local lteOpProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinaryOverloadHelp(l, "<=", r);
+
+  return
+    if prod.isJust
+    then prod.fromJust
+    else if
+      containsBy(stringEq, op.opName, ["*=", "/=", "%=", "+=", "-=", "<<=", ">>=", "&=", "|=", "^="]) &&
+      assignOpProd.isJust && assignProd.isJust
+    then constructAssignOp(_, _, _, assignOpProd.fromJust, assignProd.fromJust)
+    else if op.opName == "!=" && eqOpProd.isJust
+    then constructNot(_, _, _, env, returnType, eqOpProd.fromJust)
+    else if op.opName == ">" && lteOpProd.isJust
+    then constructNot(_, _, _, env, returnType, lteOpProd.fromJust)
+    else if op.opName == "<" && gteOpProd.isJust
+    then constructNot(_, _, _, env, returnType, gteOpProd.fromJust)
+    else if op.opName == ">=" && ltOpProd.isJust
+    then constructNot(_, _, _, env, returnType, ltOpProd.fromJust)
+    else if op.opName == "<=" && gtOpProd.isJust
+    then constructNot(_, _, _, env, returnType, gtOpProd.fromJust)
+    else binaryOpExprDefault(_, op, _, location=_);
+}
+
+function constructAssignOp
+Expr ::= e1::Expr e2::Expr l::Location assignOpProd::(Expr ::= Expr Expr Location) assignProd::(Expr ::= Expr Expr Location)
+{
+  return assignProd(e1, assignOpProd(e1, e2, l), l);
+}
+
+function constructNot
+Expr ::= e1::Expr e2::Expr l::Location env::Decorated Env returnType::Maybe<Type> prod::(Expr ::= Expr Expr Location)
+{
+  local res::Expr = prod(e1, e2, l);
+  res.env = env;
+  res.returnType = returnType;
+  return getUnaryOverload(notOp(location=l), res.typerep)(res, l);
+}
+
+-- TODO: Fix this, evaluates args twice
+{-
+function constructOr
+Expr ::= e1::Expr e2::Expr l::Location prod1::(Expr ::= Expr Expr Location) prod2::(Expr ::= Expr Expr Location)
+{
+  local res1::Expr = prod1(e1, e2, l);
+  local res2::Expr = prod2(e1, e2, l);
+  return
+    getBinaryOverload(
+      res1.typerep,
+      boolOp(andBoolOp(location=l), location=l),
+      res2.typerep)(res1, res2, l);
+}
+-}
+
+function getBinaryOverloadHelp
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type opName::String r::Type
+{
+  local lProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinOpAttribute("l" ++ opName, l, r);
+  local rProd::Maybe<(Expr ::= Expr Expr Location)> =
+    getBinOpAttribute("r" ++ opName, r, l);
+
+  return
+    if lProd.isJust
+    then lProd
+    else if rProd.isJust
+    then rProd
+    else nothing();
+}
+
+function getBinOpAttribute
+Maybe<(Expr ::= Expr Expr Location)> ::= opName::String t::Type other::Type
+{
+  t.otherType = other;
+  return
+    case opName of
+      "l=" -> t.lAssignProd
+    | "l*=" -> t.lAssignStarProd
+    | "l/=" -> t.lAssignSlashProd
+    | "l%=" -> t.lAssignPercentProd
+    | "l+=" -> t.lAssignPlusProd
+    | "l-=" -> t.lAssignMinusProd
+    | "l<<=" -> t.lAssignDoubleLtProd
+    | "l>>=" -> t.lAssignDoubleGtProd
+    | "l&=" -> t.lAssignSingleAndProd
+    | "l|=" -> t.lAssignSingleOrProd
+    | "l^=" -> t.lAssignCaratProd
+    | "l&&" -> t.lBinaryDoubleAndProd
+    | "l||" -> t.lBinaryDoubleOrProd
+    | "l&" -> t.lBinarySingleAndProd
+    | "l|" -> t.lBinarySingleOrProd
+    | "l^" -> t.lBinaryCaratProd
+    | "l<<" -> t.lBinaryDoubleLtProd
+    | "l>>" -> t.lBinaryDoubleGtProd
+    | "l==" -> t.lBinaryEqProd
+    | "l!=" -> t.lBinaryNeqProd
+    | "l>" -> t.lBinaryGtProd
+    | "l>=" -> t.lBinaryGteProd
+    | "l<" -> t.lBinaryLtProd
+    | "l<=" -> t.lBinaryLteProd
+    | "l+" -> t.lBinaryPlusProd
+    | "l-" -> t.lBinaryMinusProd
+    | "l*" -> t.lBinaryStarProd
+    | "l/" -> t.lBinarySlashProd
+    | "l%" -> t.lBinaryPercentProd
+    | "r=" -> t.rAssignProd
+    | "r*=" -> t.rAssignStarProd
+    | "r/=" -> t.rAssignSlashProd
+    | "r%=" -> t.rAssignPercentProd
+    | "r+=" -> t.rAssignPlusProd
+    | "r-=" -> t.rAssignMinusProd
+    | "r<<=" -> t.rAssignDoubleLtProd
+    | "r>>=" -> t.rAssignDoubleGtProd
+    | "r&=" -> t.rAssignSingleAndProd
+    | "r|=" -> t.rAssignSingleOrProd
+    | "r^=" -> t.rAssignCaratProd
+    | "r&&" -> t.rBinaryDoubleAndProd
+    | "r||" -> t.rBinaryDoubleOrProd
+    | "r&" -> t.rBinarySingleAndProd
+    | "r|" -> t.rBinarySingleOrProd
+    | "r^" -> t.rBinaryCaratProd
+    | "r<<" -> t.rBinaryDoubleLtProd
+    | "r>>" -> t.rBinaryDoubleGtProd
+    | "r==" -> t.rBinaryEqProd
+    | "r!=" -> t.rBinaryNeqProd
+    | "r>" -> t.rBinaryGtProd
+    | "r>=" -> t.rBinaryGteProd
+    | "r<" -> t.rBinaryLtProd
+    | "r<=" -> t.rBinaryLteProd
+    | "r+" -> t.rBinaryPlusProd
+    | "r-" -> t.rBinaryMinusProd
+    | "r*" -> t.rBinaryStarProd
+    | "r/" -> t.rBinarySlashProd
+    | "r%" -> t.rBinaryPercentProd
+    | _ -> nothing()
+    end;
+}
+
+-- Make binaryOverload depend on otherType
+abstract production hackUnusedType2
+top::Type ::=
+{
+  top.lAssignProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignStarProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignSlashProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignPercentProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignPlusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignMinusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignDoubleLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignDoubleGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignSingleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignSingleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lAssignCaratProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryDoubleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryDoubleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinarySingleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinarySingleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryCaratProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryDoubleLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryDoubleGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryEqProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryNeqProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryGteProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryLteProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryPlusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryMinusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryStarProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinarySlashProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.lBinaryPercentProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignStarProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignSlashProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignPercentProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignPlusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignMinusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignDoubleLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignDoubleGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignSingleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignSingleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rAssignCaratProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryDoubleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryDoubleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinarySingleAndProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinarySingleOrProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryCaratProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryDoubleLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryDoubleGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryEqProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryNeqProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryGtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryGteProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryLtProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryLteProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryPlusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryMinusProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryStarProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinarySlashProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  top.rBinaryPercentProd = case top.otherType of errorType() -> error("unused") | _ -> error("unused1") end;
+  
+  forwards to errorType();
+}

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
@@ -243,7 +243,10 @@ Boolean ::= a::IntegerType  b::IntegerType
 function qualifiersEq
 Boolean ::= q1::[Qualifier]  q2::[Qualifier]
 {
-  return qualifiersEqHelp(sortBy(stringLte, map((.qualname), q1)), sortBy(stringLte, map((.qualname), q2)));
+  return
+    qualifiersEqHelp(
+      sortBy(stringLte, map((.qualname), filter((.qualCheck), q1))),
+      sortBy(stringLte, map((.qualname), filter((.qualCheck), q2))));
 }
 
 -- this code is frankly horrible, but hey, something to improve in the future, I suppose.

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
@@ -1,15 +1,17 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
 {-- Type qualifiers (cv or cvr qualifiers) -}
-nonterminal Qualifier with pp, qualname;
+nonterminal Qualifier with pp, qualname, qualCheck;
 
 synthesized attribute qualname :: String;
+synthesized attribute qualCheck :: Boolean;
 
 abstract production constQualifier
 top::Qualifier ::=
 {
   top.pp = text(top.qualname);
   top.qualname = "const";
+  top.qualCheck = true;
 }
 
 abstract production volatileQualifier
@@ -17,6 +19,7 @@ top::Qualifier ::=
 {
   top.pp = text(top.qualname);
   top.qualname = "volatile";
+  top.qualCheck = true;
 }
 
 abstract production restrictQualifier
@@ -24,6 +27,7 @@ top::Qualifier ::=
 {
   top.pp = text(top.qualname);
   top.qualname = "restrict";
+  top.qualCheck = false;
 }
 
 abstract production uuRestrictQualifier
@@ -31,6 +35,7 @@ top::Qualifier ::=
 {
   top.pp = text(top.qualname);
   top.qualname = "__restrict";
+  top.qualCheck = false;
 }
 
 {-- Specifiers that apply to specific types.

--- a/extensions/string/README.md
+++ b/extensions/string/README.md
@@ -1,0 +1,13 @@
+String extension
+================
+
+This extension provides a wrapper around char* strings, providing a number of useful operators.  
+The purpose of this extension is to provide a simple demo of operator overloading.  
+
+Operators include
+* String append: s1 + s2
+* String repeat: s * i
+* String remove-all-occurences: s1 - s2
+* String equality: s1 == s2
+* String assignment from most builtin types: s1 = x
+* To string operator: tostring(x)

--- a/extensions/string/artifact/Main.sv
+++ b/extensions/string/artifact/Main.sv
@@ -1,0 +1,18 @@
+grammar artifact;
+-- Ideally, in the future, we won't have to write files like these.
+-- This file exist only because we need to do the composition at compile time.
+
+import edu:umn:cs:melt:ableC:concretesyntax as cst;
+import edu:umn:cs:melt:ableC:drivers:parseAndPrint;
+
+parser extendedParser :: cst:Root {
+  edu:umn:cs:melt:ableC:concretesyntax;
+  edu:umn:cs:melt:exts:ableC:string;
+} 
+
+function main
+IOVal<Integer> ::= args::[String] io_in::IO
+{
+  return driver(args, io_in, extendedParser);
+}
+

--- a/extensions/string/build.sh
+++ b/extensions/string/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Quick hack fix, since all of these compositions are named artifact.
+touch artifact/Main.sv
+silver -I . -I ../../../ableC -I ../gc -o ableC.jar $@ artifact
+

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/Exports.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/Exports.sv
@@ -1,0 +1,5 @@
+grammar edu:umn:cs:melt:exts:ableC:string;
+
+exports edu:umn:cs:melt:exts:ableC:string:concretesyntax:typeExpr;
+exports edu:umn:cs:melt:exts:ableC:string:concretesyntax:constructor;
+exports edu:umn:cs:melt:exts:ableC:string:abstractsyntax;

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
@@ -1,0 +1,126 @@
+grammar edu:umn:cs:melt:exts:ableC:string:abstractsyntax;
+
+imports silver:langutil;
+imports silver:langutil:pp with implode as ppImplode ;
+
+imports edu:umn:cs:melt:ableC:abstractsyntax;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
+imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+--imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
+
+--imports edu:umn:cs:melt:exts:ableC:gc;
+
+abstract production constructString
+top::Expr ::= e::Expr
+{
+  top.typerep = stringType();
+  forwards to
+    case e.typerep.toStringProd of
+      just(p) -> p(e, top.location)
+    | nothing() -> errorExpr([err(top.location, s"String representation of ${showType(e.typerep)} not defined")], location=top.location)
+    end;
+}
+
+abstract production constructStringFromString
+top::Expr ::= e::Expr
+{
+  forwards to e;
+}
+
+abstract production constructStringFromChar
+top::Expr ::= e::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_char_to_string", location=builtIn()),
+      consExpr(e, nilExpr()),
+      location=top.location);
+}
+
+abstract production constructStringFromInt
+top::Expr ::= e::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_int_to_string", location=builtIn()),
+      consExpr(e, nilExpr()),
+      location=top.location);
+}
+
+abstract production constructStringFromFloat
+top::Expr ::= e::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_float_to_string", location=builtIn()),
+      consExpr(e, nilExpr()),
+      location=top.location);
+}
+
+abstract production assignString
+top::Expr ::= lhs::Expr rhs::Expr
+{
+  forwards to
+    binaryOpExprDefault(
+      lhs,
+      assignOp(eqOp(location=builtIn()), location=builtIn()),
+      constructString(rhs, location=builtIn()),
+      location=builtIn());
+}
+
+abstract production appendString
+top::Expr ::= e1::Expr e2::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_append_string", location=builtIn()),
+      consExpr(
+        constructString(e1, location=builtIn()),
+        consExpr(
+          constructString(e2, location=builtIn()),
+          nilExpr())),
+      location=top.location);
+}
+
+abstract production removeString
+top::Expr ::= e1::Expr e2::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_remove_string", location=builtIn()),
+      consExpr(
+        constructString(e1, location=builtIn()),
+        consExpr(
+          constructString(e2, location=builtIn()),
+          nilExpr())),
+      location=top.location);
+}
+
+abstract production repeatString
+top::Expr ::= e1::Expr e2::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_repeat_string", location=builtIn()),
+      consExpr(e1, consExpr(e2, nilExpr())),
+      location=top.location);
+}
+
+abstract production eqString
+top::Expr ::= e1::Expr e2::Expr
+{
+  forwards to
+    directCallExpr(
+      name("_eq_string", location=builtIn()),
+      consExpr(e1, consExpr(e2, nilExpr())),
+      location=top.location);
+}
+
+{-
+ - New location for expressions which don't have real locations
+ -}
+abstract production builtIn
+top::Location ::=
+{
+  forwards to loc("Built In", 0, 0, 0, 0, 0, 0);
+}

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
@@ -1,0 +1,125 @@
+grammar edu:umn:cs:melt:exts:ableC:string:abstractsyntax;
+
+synthesized attribute toStringProd::Maybe<(Expr ::= Expr Location)> occurs on Type, BuiltinType;--, IntegerType, RealType;
+
+aspect default production
+top::Type ::=
+{
+  top.toStringProd = nothing();
+}
+
+aspect default production
+top::BuiltinType ::=
+{
+  top.toStringProd = nothing();
+}
+{-
+aspect default production
+top::IntegerType ::=
+{
+  top.toStringProd = nothing();
+}
+
+aspect default production
+top::RealType ::=
+{
+  top.toStringProd = nothing();
+}
+-}
+abstract production stringTypeExpr 
+top::BaseTypeExpr ::= 
+{
+  forwards to directTypeExpr(stringType());
+}
+
+abstract production stringType
+top::Type ::= 
+{
+  top.lBinaryPlusProd =
+    case top.otherType.toStringProd of
+      just(p) -> just(appendString(_, _, location=_))
+    | _ -> nothing()
+    end;
+  top.rBinaryPlusProd = top.lBinaryPlusProd;
+  
+  top.lBinaryMinusProd =
+    case top.otherType.toStringProd of
+      just(p) -> just(removeString(_, _, location=_))
+    | _ -> nothing()
+    end;
+  top.rBinaryMinusProd = top.lBinaryPlusProd;
+  
+  top.lBinaryStarProd =
+    if top.otherType.isIntegerType
+    then just(repeatString(_, _, location=_))
+    else nothing();
+  
+  top.lBinaryEqProd =
+    case top.otherType of
+      stringType() -> just(eqString(_, _, location=_))
+    | pointerType(_, builtinType(_, signedType(charType()))) ->
+        just(eqString(_, _, location=_))
+    | _ -> nothing()
+    end;
+  top.rBinaryEqProd = top.lBinaryEqProd;
+  
+  top.lAssignProd = just(assignString(_, _, location=_));
+  top.rAssignProd = 
+    case top.otherType of
+      pointerType(_, builtinType(_, signedType(charType()))) ->
+        just(
+          binaryOpExprDefault(
+            _,
+            assignOp(eqOp(location=builtIn()), location=builtIn()),
+            _,
+            location=_))
+    | _ -> nothing()
+    end;
+  
+  top.toStringProd = just(constructStringFromString(_, location=_));
+
+  forwards to pointerType([], builtinType([constQualifier()], signedType(charType())));
+}
+
+aspect production pointerType
+top::Type ::= quals::[Qualifier] sub::Type
+{
+  top.toStringProd =
+    case sub of
+      builtinType(_, signedType(charType())) -> just(constructStringFromString(_, location=_))
+    | builtinType(_, unsignedType(charType())) -> just(constructStringFromString(_, location=_))
+    | _ -> nothing()
+    end;
+}
+
+aspect production builtinType
+top::Type ::= quals::[Qualifier] sub::BuiltinType
+{
+  top.toStringProd = sub.toStringProd;
+}
+
+aspect production realType
+top::BuiltinType ::= sub::RealType
+{
+  top.toStringProd = just(constructStringFromFloat(_, location=_));
+}
+
+aspect production signedType
+top::BuiltinType ::= sub::IntegerType
+{
+  top.toStringProd = 
+    case sub of
+      charType() -> just(constructStringFromChar(_, location=_))
+    | _ -> just(constructStringFromInt(_, location=_))
+    end;
+}
+
+aspect production unsignedType
+top::BuiltinType ::= sub::IntegerType
+{
+  top.toStringProd = 
+    case sub of
+      charType() -> just(constructStringFromChar(_, location=_))
+    | _ -> just(constructStringFromInt(_, location=_))
+    end;
+}

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/concretesyntax/constructor/Constructor.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/concretesyntax/constructor/Constructor.sv
@@ -1,0 +1,21 @@
+grammar edu:umn:cs:melt:exts:ableC:string:concretesyntax:constructor;
+
+imports edu:umn:cs:melt:ableC:concretesyntax;
+imports silver:langutil only ast;
+
+imports edu:umn:cs:melt:ableC:abstractsyntax;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
+imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+--imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
+
+import edu:umn:cs:melt:exts:ableC:string;
+
+-- Spurious import, to trigger the tests on build.
+import edu:umn:cs:melt:exts:ableC:string:mda_test;
+
+marking terminal ToString_t 'tostring' lexer classes {Ckeyword};
+
+-- Someday, we may overload function application instead
+concrete productions top::PrimaryExpr_c
+| 'tostring' '(' s::Expr_c ')'
+  { top.ast = constructString(s.ast, location=top.location); }

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/concretesyntax/typeExpr/TypeExpr.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/concretesyntax/typeExpr/TypeExpr.sv
@@ -1,0 +1,21 @@
+grammar edu:umn:cs:melt:exts:ableC:string:concretesyntax:typeExpr;
+
+imports edu:umn:cs:melt:ableC:concretesyntax;
+imports silver:langutil only ast;
+
+imports edu:umn:cs:melt:ableC:abstractsyntax;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
+imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+--imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
+
+import edu:umn:cs:melt:exts:ableC:string;
+
+-- Spurious import, to trigger the tests on build.
+import edu:umn:cs:melt:exts:ableC:string:mda_test;
+
+marking terminal String_t 'string' lexer classes {Ckeyword};
+
+concrete productions top::TypeSpecifier_c
+| 'string'
+    { top.realTypeSpecifiers = [stringTypeExpr()];
+      top.preTypeSpecifiers = []; }

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/mda_test/MDA.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/mda_test/MDA.sv
@@ -1,0 +1,11 @@
+grammar edu:umn:cs:melt:exts:ableC:string:mda_test;
+
+import edu:umn:cs:melt:ableC:host;
+
+copper_mda testLambdaExpr(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:string:concretesyntax:constructor;
+}
+
+copper_mda testLambdaExpr(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:string:concretesyntax:typeExpr;
+}

--- a/extensions/string/example1.xc
+++ b/extensions/string/example1.xc
@@ -1,0 +1,65 @@
+#include <string.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  string a = "abc";
+  printf("a: %s\n", a);
+
+  if (a != "abc")
+    return 1;
+
+  if (a == "abcd")
+    return 2;
+
+  string b = "def";
+  printf("b: %s\n", b);
+  string c = "ghi";
+  printf("c: %s\n", c);
+  string d = a + b;
+  printf("d: %s\n", d);
+
+  if (d != "abcdef")
+    return 3;
+
+  d += c;
+  d += 'j';
+  printf("d: %s\n", d);
+
+  if (d != "abcdefghij")
+    return 4;
+
+  string e = tostring(-1234 + 5);
+  printf("e: %s\n", e);
+
+  if (e != "-1229")
+    return 5;
+  
+  string f = tostring(-1234) + 5;
+  printf("f: %s\n", f);
+
+  if (f != "-12345")
+    return 6;
+
+  string g = "xyz";
+  string h = g * 5;
+  printf("h: %s\n", h);
+
+  if (h != "xyzxyzxyzxyzxyz")
+    return 7;
+  
+  g *= 7;
+  printf("g: %s\n", g);
+
+  if (g != "xyzxyzxyzxyzxyzxyzxyz")
+    return 8;
+
+  string i = tostring(3.14);
+  printf("i: %s\n", i);
+
+  if (i != "3.140000")
+    return 9;
+
+  return 0;
+}

--- a/extensions/string/example2-remove.xc
+++ b/extensions/string/example2-remove.xc
@@ -1,0 +1,30 @@
+#include <string.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  string test = "abcdefgabcabcxyzabcxyxyxyz";
+  
+  string a = test - "abc";
+  printf("a: %s\n", a);
+  if (a != "defgxyzxyxyxyz")
+    return 1;
+  
+  string b = test - "xyz";
+  printf("b: %s\n", b);
+  if (b != "abcdefgabcabcabcxyxy")
+    return 2;
+  
+  string c = test - "xyx";
+  printf("c: %s\n", c);
+  if (c != "abcdefgabcabcxyzabcyxyz")
+    return 3;
+
+  test -= "abca";
+  printf("test: %s\n", test);
+  if (test != "abcdefgbcxyzabcxyxyxyz")
+    return 4;
+
+  return 0;
+}

--- a/extensions/string/example3-include-error.xc
+++ b/extensions/string/example3-include-error.xc
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  string a = "abc";
+  printf("a: %s\n", a);
+
+  if (d != "abc")
+    return 1;
+
+  string b = "def";
+  printf("b: %s\n", b);
+  string c = "ghi";
+  printf("c: %s\n", c);
+  string d = a + b;
+  printf("d: %s\n", d);
+
+  if (d != "abcdef")
+    return 2;
+
+  d += c;
+  printf("d: %s\n", d);
+
+  if (d != "abcdefghi")
+    return 3;
+
+  return 0;
+}

--- a/extensions/string/example4-type-errors.xc
+++ b/extensions/string/example4-type-errors.xc
@@ -1,0 +1,13 @@
+#include <string.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {int a;} t;
+
+int main(int argc, char **argv) {
+  string a = tostring((t){4});
+  string b = 4 * "q";
+
+  return 0;
+}

--- a/extensions/string/include/string.xh
+++ b/extensions/string/include/string.xh
@@ -1,0 +1,63 @@
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <limits.h>
+#include <gc.h>
+
+static inline string _int_to_string(int i) {
+  string result = GC_malloc((CHAR_BIT * sizeof(i) - 1) / 3 + 2);
+  sprintf((char*)result, "%d", i);
+  return result;
+}
+
+static inline string _float_to_string(double f) {
+  string result = GC_malloc((CHAR_BIT * sizeof(f) - 1) / 3 + 2);
+  sprintf((char*)result, "%f", f);
+  return result;
+}
+
+static inline string _char_to_string(char c) {
+  char *result = GC_malloc(2);
+  result[0] = c;
+  result[1] = '\0';
+  return (string)result;
+}
+
+static inline bool _eq_string(string s1, string s2) {
+  return !strcmp(s1, s2);
+}
+
+static inline string _append_string(string s1, string s2) {
+  string result = GC_malloc(strlen(s1) + strlen(s2) + 1);
+  strcpy((char*)result, s1);
+  strcat((char*)result, s2);
+  return result;
+}
+
+static inline string _repeat_string(string s, int num) {
+  char *result = GC_malloc(strlen(s) * num + 1);
+  result[0] = '\0';
+  int i;
+  for (int i = 0; i < num; i++)
+    strcat(result, s);
+  return (string)result;
+}
+
+static inline string _remove_string(string s1, string s2) {
+  int i, j;
+  int len1 = strlen(s1);
+  int len2 = strlen(s2);
+  char *result = GC_malloc(strlen(s1) + 1);
+  for (i = 0, j = 0; i < len1; i++) {
+    if (i > len1 - len2 || strncmp((const char*)s1 + i, s2, len2)) {
+      result[j] = s1[i];
+      j++;
+    }
+    else {
+      i += len2 - 1;
+    }
+  }
+  result[j] += '\0';
+  
+  return (string)result;
+}

--- a/extensions/string/init_build.sh
+++ b/extensions/string/init_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source $ABLEC_PATH/extensions/gc/init_build.sh # Don't really need everything, but loads gc library dependancies
+
+export ABLEC_SOURCE+=" $ABLEC_PATH/extensions/string/edu.umn.cs.melt.exts.ableC.string/**/*"
+export SILVER_INCLUDES+=" -I $ABLEC_PATH/extensions/string"
+export TRANSLATE_DEPENDS+="$ABLEC_PATH/extensions/string/include/*"
+export CPPFLAGS+=" -I$ABLEC_PATH/extensions/string/include"

--- a/extensions/string/make
+++ b/extensions/string/make
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+../../testing/build/make ../.. $@

--- a/testing/build/makefile
+++ b/testing/build/makefile
@@ -28,7 +28,7 @@ endif
 %.c: %.xc $(JAR_NAME)
 ifdef TESTING
 	echo -n "Translating $(shell basename $<)... "
-	if [ -z $(findstring error, $<) ]; then (java $(JAVA_FLAGS) -jar $(JAR_NAME) $< $(CPPFLAGS) &> $@.test.out && echo "passed" || (echo "failed"; touch .tests_failed; exit 2)) else (java $(JAVA_FLAGS) -jar $(JAR_NAME) $< $(CPPFLAGS) &> $@.test.out && (echo "failed (did not error)"; touch .tests_failed; exit 3) || echo "passed (did not compile)") fi
+	if [ -z $(findstring error, $<) ]; then (java $(JAVA_FLAGS) -jar $(JAR_NAME) $< $(CPPFLAGS) &> $@.test.out && echo "passed" || (echo "failed"; touch .tests_failed; exit 2)) else if java $(JAVA_FLAGS) -jar $(JAR_NAME) $< $(CPPFLAGS) &> $@.test.out; then echo "failed (did not error)"; rm $@; touch .tests_failed; exit 3; else echo "passed (did not compile)"; fi; fi
 else
 	java $(JAVA_FLAGS) -jar $(JAR_NAME) $< $(CPPFLAGS)
 endif


### PR DESCRIPTION
I have added operator overloading to ableC.  Let me know what you think.  

I basically added a Maybe dispatch attribute to type for each unary operator.   If the dispatch is not defined, then the usual production is used.  

For the binary operators, the double-dispatch resolution was inspired by operator overloading in Python.  There is a left and right dispatch attribute for each binary operator, and also an inherited attribute that provides the type of the other operand.  The left dispatch is checked first, if it is missing, the right is tried.  If there is no right dispatch, then the existing machinery for built-in types is used.  This also means that there is no additional error checking needed when overloading an operator; if you don't define it, then you get the error message that is from using invalid types in C.  

Many operators are also often defined in terms of each other.  For example, it would be tedious to write +=, *=, !=, etc. all manually when =, !, +, *, ==, etc. are already defined.  To remedy this, I am auto-generating these kinds of operators as defaults if their components are overloaded.  Currently, I am only generating > from <= and < from >= and vice versa, but it would be better if all these could be generated from one equality and one comparison operator.  I haven't done this yet as the naive approach would result in re-evaluating expressions, but I could do this by generating a statement-expression that evaluates the operands to temporary variables.  This would also require the and/or operators to be defined.  Anyway, there is a lot more I could be doing with operator default generation, but I don't want to make it too complicated.  The way it is it works well without any unexpected behavior.  

To make all this more concrete, I created an example string extension, providing strings with nice operations built in, such as appending, equality, etc.  There are examples included.  