### PR TITLE
improve error message when gcc doesn't support C11

### DIFF
--- a/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -43,7 +43,7 @@ IOVal<Integer> ::= args::[String] ioIn::IO
           systemM(
           fullCppCmd);
         if mkCppFile != 0 then {
-          printM("CPP call failed.\n");
+          printM("CPP call failed: " ++ fullCppCmd ++ "\n");
           return 3;
         } else {
           text :: String <- readFileM(cppFileName);

--- a/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -55,7 +55,7 @@ IOVal<Integer> ::= args::[String] ioIn::IO
   else if !isF.iovalue then
     ioval(print("File \"" ++ fileName ++ "\" not found.\n", isF.io), 1)
   else if mkCppFile.iovalue != 0 then
-    ioval(print("CPP call failed.\n", mkCppFile.io), 3)
+    ioval(print("CPP call failed: " ++ fullCppCmd ++ "\n", mkCppFile.io), 3)
   else if !result.parseSuccess then
     ioval(print(result.parseErrors ++ "\n", text.io), 2)
   else if containsBy(stringEq, "--show-ast", args) then

--- a/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -55,7 +55,7 @@ IOVal<Integer> ::= args::[String] ioIn::IO
   else if !isF.iovalue then
     ioval(print("File \"" ++ fileName ++ "\" not found.\n", isF.io), 1)
   else if mkCppFile.iovalue != 0 then
-    ioval(print("CPP call failed: " ++ fullCppCmd ++ "\n", mkCppFile.io), 3)
+    ioval(print("CPP call failed.\n", mkCppFile.io), 3)
   else if !result.parseSuccess then
     ioval(print(result.parseErrors ++ "\n", text.io), 2)
   else if containsBy(stringEq, "--show-ast", args) then


### PR DESCRIPTION
Error message was "CPP call failed."
Had to grep for that message to see that there's a --show-cpp option.
Had to run again with --show-cpp to see the command:
	gcc -E -x c -D _POSIX_C_SOURCE -std=gnu1x -I .  "test.xc" > test.gen_cpp
Had to run that command to see the root error:
	cc1: error: unrecognized command line option "-std=gnu1x"

This commit updates the error message to be:
CPP call failed: gcc -E -x c -D _POSIX_C_SOURCE -std=gnu1x -I .  "test.xc" > test.gen_cpp

If that's too much info, maybe "CPP call failed: try --show-cpp for more info"?

It would be nice to see the "-std=gnu1x" error immediately, but I'm not sure how
to print that out in Silver.