### PR TITLE
Feature/templating

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -5,7 +5,7 @@
 -- Declaration is rooted in External, but also in stmts. Either a variableDecl or a typedefDecl.
 -- ParameterDecl should probably be something special, distinct from variableDecl.
 
-nonterminal Decls with pps, host<Decls>, lifted<Decls>, errors, globalDecls, defs, env, isTopLevel, returnType, freeVariables;
+nonterminal Decls with pps, host<Decls>, lifted<Decls>, errors, globalDecls, defs, globalDeclEnv, env, isTopLevel, returnType, freeVariables;
 
 autocopy attribute isTopLevel :: Boolean;
 
@@ -21,6 +21,7 @@ top::Decls ::= h::Decl  t::Decls
     h.freeVariables ++
     removeDefsFromNames(h.defs, t.freeVariables);
   
+  t.globalDeclEnv = error("Demanded globalDeclEnv in consDecl");
   t.env = addEnv(h.defs, top.env);
 }
 
@@ -56,6 +57,8 @@ top::Decl ::= d::Decls
   top.globalDecls := d.globalDecls;
   top.defs = d.defs;
   top.freeVariables = d.freeVariables;
+  
+  d.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
 }
 
 abstract production variableDecls
@@ -67,7 +70,7 @@ top::Decl ::= storage::[StorageClass]  attrs::[Attribute]  ty::BaseTypeExpr  dcl
       ppAttributes(attrs) ::
       [ty.pp, space(), ppImplode(text(", "), dcls.pps), semi()]);
   top.errors := ty.errors ++ dcls.errors;
-  top.globalDecls := dcls.globalDecls;
+  top.globalDecls := ty.globalDecls ++ dcls.globalDecls;
   top.defs = ty.defs ++ dcls.defs;
   top.freeVariables = ty.freeVariables ++ dcls.freeVariables;
   
@@ -303,6 +306,8 @@ top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty:
 
   body.env = addEnv(top.defs ++ parameters.defs ++ decls.defs ++ body.functiondefs, 
                     openScope(addEnv(bty.defs, top.env)));
+  
+  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
   decls.isTopLevel = false;
   
   

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -474,7 +474,7 @@ Maybe<String> ::= attrs::[Attribute]
 {
   return
     case attrs of
-      gccAttribute(ats) :: rest -> orElse(getRefIdFromAttribs(ats), getRefIdFromAttributes(attrs))
+      gccAttribute(ats) :: rest -> orElse(getRefIdFromAttribs(ats), getRefIdFromAttributes(rest))
     | _ :: rest -> getRefIdFromAttributes(rest)
     | [] -> nothing()
     end;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Expr.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Expr.sv
@@ -223,10 +223,15 @@ top::Expr ::= lhs::Expr  deref::Boolean  rhs::Name
       errorType()
     else if null(valueitems) then
       errorType()
-    else head(valueitems).typerep;
-  
-  -- TODO Add qualifiers from quals_refid.fst to the type!
-  -- TODO: error checking!! Type checking
+    else addQualifiers(quals_refid.fst, head(valueitems).typerep);
+  top.errors <-
+    if null(refids) then 
+      [err(lhs.location, "expression does not have defined fields (got " ++ showType(lhs.typerep) ++ ")")]
+    else if null(valueitems) then
+      if deref
+      then [err(lhs.location, "expression does not have pointer to struct or union type (got " ++ showType(lhs.typerep) ++ ")")]
+      else [err(lhs.location, "expression does not have struct or union type (got " ++ showType(lhs.typerep) ++ ")")]
+    else [];
 }
 abstract production binaryOpExpr
 top::Expr ::= lhs::Expr  op::BinOp  rhs::Expr

--- a/edu.umn.cs.melt.ableC/abstractsyntax/ExprContainers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/ExprContainers.sv
@@ -66,6 +66,7 @@ top::Exprs ::= h::Expr  t::Exprs
     if null(top.expectedTypes) then
       if top.callVariadic then []
       else
+        -- TODO: These indices are broken, maybe backwards?
         [err(top.callExpr.location, s"call expected ${toString(top.argumentPosition)} arguments, got ${toString(top.argumentPosition + t.count - 1)}")]
     else
       if !typeAssignableTo(head(top.expectedTypes).withoutTypeQualifiers, h.typerep) then
@@ -94,7 +95,7 @@ top::Exprs ::=
   top.argumentErrors =
     if null(top.expectedTypes) then []
     else
-      [err(top.callExpr.location, s"call expected ${toString(top.argumentPosition + length(top.expectedTypes))} arguments, got only ${toString(top.argumentPosition)}")];
+      [err(top.callExpr.location, s"call expected ${toString(top.argumentPosition + length(top.expectedTypes) - 1)} arguments, got only ${toString(top.argumentPosition - 1)}")];
 }
 
 function appendExprs

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -2,7 +2,8 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
 {- 
 Expressions that want to specify declartions to lift to a global scope
-do so by forwarding to the host production `injectGlobalDecls`.  
+do so by forwarding to the host production `injectGlobalDecls` (or one
+of the corresponding ones for Type or BaseTypeExpr.)  
 
 After extracting the `host` tree, there are no extension constructs,
 but declarations need to be lifted to the proper place. 
@@ -17,9 +18,13 @@ either `globalDecls` or in `lifted`.
   put into `lifted`.
 - On all other nonterminals, `globalDecls` need not be empty.
 
-Another invariant is that declarations in globalDecls declare unique
-names.  Thus no fear of name clashes.  This is unrealistic, but we can
-address this later.
+Another invariant is that declarations in globalDecls with the same name
+refer to an identical declaration, so that any duplicates can be safely
+removed.  This is left up to the extension writer for now, but there may
+a better solution.  
+
+It would be nice to move all of this to its own grammar, but aspecting
+everything for lifted and globalDecls would be kind of a pain
 -}
 
 synthesized attribute lifted<a>::a;
@@ -27,37 +32,127 @@ synthesized attribute lifted<a>::a;
 -- String is name of decl, could be used to remove duplicates
 synthesized attribute globalDecls::[Pair<String Decl>] with ++;
 
+-- List of names of global decls that have already been inserted, to avoid lifting and inserting
+-- the same decl at different locations
+inherited attribute globalDeclEnv::[String];
+
 abstract production injectGlobalDecls
 top::Expr ::= globalDecls::[Pair<String Decl>] lifted::Expr
 {
- top.pp = pp"injectGlobalDecls {${ppImplode(pp"\n", decls.pps)}} (${lifted.pp})";
- top.host = injectGlobalDecls(zipWith(pair, names, unfoldDecl(decls.host)), lifted.host, location=top.location);
+  top.pp = pp"injectGlobalDecls {${ppImplode(pp"\n", decls.pps)}} (${lifted.pp})";
+  top.host = injectGlobalDecls(zipWith(pair, names, unfoldDecl(decls.host)), lifted.host, location=top.location);
  
- local decls::Decls = foldDecl(map(snd, globalDecls));
- local names::[String] = map(fst, globalDecls);
+  local decls::Decls = foldDecl(map(snd, globalDecls));
+  local names::[String] = map(fst, globalDecls);
 
- decls.env = globalEnv(top.env);
- decls.isTopLevel = true;
- decls.returnType = top.returnType;
+  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
+  decls.env = globalEnv(top.env);
+  decls.isTopLevel = true;
+  decls.returnType = top.returnType;
 
- top.errors := decls.errors;
+  top.errors <- decls.errors;
 
  -- Note that the invariant over `globalDecls` and `lifted` is maintained.
- top.globalDecls :=
-   decls.globalDecls ++ 
-   zipWith(pair, names, unfoldDecl(decls.lifted)) ++
-   lifted.globalDecls;
- -- It should hold that names and unfoldDecl(decls.lifted) are the same length and
- -- correctly correspond to one another.
- top.lifted = lifted.lifted;
+  top.globalDecls :=
+    decls.globalDecls ++ 
+    zipWith(pair, names, unfoldDecl(decls.lifted)) ++
+    lifted.globalDecls;
+  -- It should hold that names and unfoldDecl(decls.lifted) are the same length and
+  -- correctly correspond to one another.
+  top.lifted = lifted.lifted;
  
- lifted.env = addEnv(decls.defs, top.env);
+  lifted.env = addEnv(decls.defs, top.env);
  
- -- TODO: We are adding the new env elements to the current scope, when they should really be global
- -- Shouldn't be a problem unless there are name conflicts, doing this the right way would be less
- -- efficent.  
- forwards to lifted
- with {env = lifted.env;};
+  -- TODO: We are adding the new env elements to the current scope, when they should really be global
+  -- Shouldn't be a problem unless there are name conflicts, doing this the right way would be less
+  -- efficent.  
+  forwards to lifted
+  with {env = lifted.env;};
+}
+
+-- Same as injectGlobalDecls, but on BaseTypeExpr
+abstract production injectGlobalDeclsTypeExpr
+top::BaseTypeExpr ::= globalDecls::[Pair<String Decl>] lifted::BaseTypeExpr
+{
+  top.pp = pp"injectGlobalDeclsTypeExpr {${ppImplode(pp"\n", decls.pps)}} (${lifted.pp})";
+  top.host = injectGlobalDeclsTypeExpr(zipWith(pair, names, unfoldDecl(decls.host)), lifted.host);
+ 
+  local decls::Decls = foldDecl(map(snd, globalDecls));
+  local names::[String] = map(fst, globalDecls);
+
+  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
+  decls.env = globalEnv(top.env);
+  decls.isTopLevel = true;
+  decls.returnType = top.returnType;
+
+  top.errors <- decls.errors;
+
+ -- Note that the invariant over `globalDecls` and `lifted` is maintained.
+  top.globalDecls :=
+    decls.globalDecls ++ 
+    zipWith(pair, names, unfoldDecl(decls.lifted)) ++
+    lifted.globalDecls;
+  -- It should hold that names and unfoldDecl(decls.lifted) are the same length and
+  -- correctly correspond to one another.
+  top.lifted = lifted.lifted;
+ 
+  lifted.env = addEnv(decls.defs, top.env);
+ 
+  -- TODO: We are adding the new env elements to the current scope, when they should really be global
+  -- Shouldn't be a problem unless there are name conflicts, doing this the right way would be less
+  -- efficent.  
+  forwards to lifted
+  with {env = lifted.env;};
+}
+
+{- Lifting mechanism for types
+ - Note that the invariant must be changed here, since we don't have access to an environment.  
+ - Instead, we simply lift everything to the top of the type, where the decls are then decorated
+ - within directTypeExpr
+ -}
+abstract production injectGlobalDeclsType
+top::NoncanonicalType ::= globalDecls::[Pair<String Decl>] lifted::Type
+{
+  top.canonicalType = lifted;
+  top.lpp = pp"injectGlobalDeclsTypeExpr {<not shown>} (${lifted.lpp})";
+  top.rpp = lifted.rpp;
+  top.host = injectGlobalDeclsType(globalDecls, lifted.host);
+  top.lifted = liftedType(lifted.lifted);
+  top.globalDecls := globalDecls;
+}
+
+-- A noncanonical type that is really just a normal type, after the lifting transformation has happened
+abstract production liftedType
+top::NoncanonicalType ::= lifted::Type
+{
+  propagate host, lifted;
+  top.canonicalType = lifted;
+  top.lpp = lifted.lpp;
+  top.rpp = lifted.rpp;
+  top.globalDecls := lifted.globalDecls;
+}
+
+-- directTypeExpr now functions similarly to injectGlobalDecls, except that the decls to be lifted
+-- are provided only via result.globalDecls
+aspect production directTypeExpr
+top::BaseTypeExpr ::= result::Type
+{
+  top.lifted = freshenDirectTypeExpr(result.lifted);
+  
+  local decls::Decls = foldDecl(map(snd, result.globalDecls));
+  local names::[String] = map(fst, result.globalDecls);
+
+  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
+  decls.env = globalEnv(top.env);
+  decls.isTopLevel = true;
+  decls.returnType = top.returnType;
+  
+  top.errors <- decls.errors;
+
+  -- Note that the invariant over `globalDecls` and `lifted` is maintained.
+  top.globalDecls :=
+    decls.globalDecls ++ 
+    zipWith(pair, names, unfoldDecl(decls.lifted));
 }
 
 -- Inserted globalDecls before h. Should only ever get used by top-level 
@@ -65,28 +160,31 @@ top::Expr ::= globalDecls::[Pair<String Decl>] lifted::Expr
 abstract production consGlobalDecl
 top::Decls ::= h::Decl  t::Decls
 {
- propagate host;
+  propagate host;
  
- local newDecls::Decls =
-   foldDecl(map(snd, removeDuplicateGlobalDeclPairs(h.globalDecls, [])));
+  local newGlobalDeclPairs::[Pair<String Decl>] =
+    removeDuplicateGlobalDeclPairs(h.globalDecls, top.globalDeclEnv);
+  local newDecls::Decls = foldDecl(map(snd, newGlobalDeclPairs));
 
- top.globalDecls := [];
- top.lifted =
-   if !null(t.globalDecls)
-   then error("consGlobalDecl tail has global decls!")
-   else consDecl( 
-          decls(newDecls),
-          consDecl(
-            h.lifted,
-            t.lifted));
+  top.globalDecls := [];
+  top.lifted =
+    if !null(t.globalDecls)
+    then error("consGlobalDecl tail has global decls!")
+    else consDecl( 
+           decls(newDecls),
+           consDecl(
+             h.lifted,
+             t.lifted));
   
+  t.globalDeclEnv = top.globalDeclEnv ++ map(fst, newGlobalDeclPairs);
   t.env = addEnv(h.defs, top.env);
   
   -- define pp, env, defs, etc.
   forwards to consDecl(h, t);
 }
 
--- not used here, call with sofar as [] initially.
+-- removes duplicate global decls before inserting them
+-- sofar is the list of names that have already been inserted, passed in to globalDecls via globalDeclEnv
 function removeDuplicateGlobalDeclPairs
 [Pair<String Decl>] ::= ds::[Pair<String Decl>]  sofar::[String]
 {

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
@@ -15,6 +15,8 @@ top::Root ::= d::Decls
   top.pp = terminate(line(), d.pps);
   top.errors := d.errors;
   top.globalDecls := d.globalDecls;
+  
+  d.globalDeclEnv = [];
 --  d.env = addEnv(builtinfunctions:initialEnv;
   d.env = addEnv(builtinfunctions:getInitialEnvDefs(), top.env);
   d.isTopLevel = true;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -82,25 +82,16 @@ top::BaseTypeExpr ::= msg::[Message]  ty::BaseTypeExpr
  - e.g. builtin types. 
  - This should be the only place in the AST where a type is used directly in a host production, in
  - order for special handling of refId freshening and lifting to work correctly
- - Handling of lifted and globalDecls is defined in Lifted.sv
+ - Handling of host, lifted and globalDecls is defined in Lifted.sv
  -}
 abstract production directTypeExpr
 top::BaseTypeExpr ::= result::Type
 {
-  top.host = freshenDirectTypeExpr(result.host);
   top.pp = cat(result.lpp, result.rpp);
   top.typerep = result;
   top.errors := [];
   top.defs = [];
   top.freeVariables = [];
-}
-
-{-- When applying a functor attribute, we need to update the refIds in any types in directTypeExprs
- - to point to the new refIds defined in the new tags -}
-abstract production freshenDirectTypeExpr
-top::BaseTypeExpr ::= result::Type
-{
-  forwards to directTypeExpr(freshenRefIds(top.env, result));
 }
 
 {-- A reference to a tag type. e.g. 'struct foo' not 'struct foo {...}' -}

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -79,16 +79,18 @@ top::BaseTypeExpr ::= msg::[Message]  ty::BaseTypeExpr
 }
 
 {-- A TypeExpr that simply yields a type directly, no interpretation necessary.
- - e.g. builtin types. -}
+ - e.g. builtin types. 
+ - This should be the only place in the AST where a type is used directly in a host production, in
+ - order for special handling of refId freshening and lifting to work correctly
+ - Handling of lifted and globalDecls is defined in Lifted.sv
+ -}
 abstract production directTypeExpr
 top::BaseTypeExpr ::= result::Type
 {
-  top.host = freshenDirectTypeExpr(result);
-  top.lifted = freshenDirectTypeExpr(result);
+  top.host = freshenDirectTypeExpr(result.host);
   top.pp = cat(result.lpp, result.rpp);
   top.typerep = result;
   top.errors := [];
-  top.globalDecls := [];
   top.defs = [];
   top.freeVariables = [];
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypesBuiltin.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypesBuiltin.sv
@@ -5,7 +5,7 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax;
  - Design note: signed and unsigned having 'IntegerType' is ableC's own idiosyntactic design.
  - This can be changed if it turns out that's an annoying choice somehow.
  -}
-nonterminal BuiltinType with pp, host<BuiltinType>, integerPromotionsBuiltin, defaultArgumentPromotionsBuiltin, isIntegerType, isArithmeticType;
+nonterminal BuiltinType with pp, host<BuiltinType>, mangledName, integerPromotionsBuiltin, defaultArgumentPromotionsBuiltin, isIntegerType, isArithmeticType;
 
 synthesized attribute integerPromotionsBuiltin :: BuiltinType;
 synthesized attribute defaultArgumentPromotionsBuiltin :: BuiltinType;
@@ -19,6 +19,7 @@ top::BuiltinType ::=
 {
   propagate host;
   top.pp = text("void");
+  top.mangledName = "void";
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin = top;
   top.isIntegerType = false;
@@ -31,6 +32,7 @@ top::BuiltinType ::=
 {
   propagate host;
   top.pp = text("_Bool");
+  top.mangledName = "bool";
   top.integerPromotionsBuiltin = signedType(intType()); -- yep.
   top.defaultArgumentPromotionsBuiltin = top.integerPromotionsBuiltin;
   top.isIntegerType = true;
@@ -43,6 +45,7 @@ top::BuiltinType ::= rt::RealType
 {
   propagate host;
   top.pp = rt.pp;
+  top.mangledName = "real_" ++ rt.mangledName;
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin =
     realType(
@@ -60,6 +63,7 @@ top::BuiltinType ::= rt::RealType
 {
   propagate host;
   top.pp = concat([ text("_Complex "), rt.pp ]);
+  top.mangledName = "complex_" ++ rt.mangledName;
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin =
     complexType(
@@ -77,6 +81,7 @@ top::BuiltinType ::= rt::RealType
 {
   propagate host;
   top.pp = concat([ text("_Imaginary "), rt.pp ]);
+  top.mangledName = "imaginary_" ++ rt.mangledName;
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin =
     imaginaryType(
@@ -99,6 +104,7 @@ top::BuiltinType ::= it::IntegerType
     | charType() -> ""
     | _ -> "signed "
     end;
+  top.mangledName = "signed_" ++ it.mangledName;
 
   top.integerPromotionsBuiltin = 
     signedType(
@@ -118,6 +124,7 @@ top::BuiltinType ::= it::IntegerType
 {
   propagate host;
   top.pp = concat([ text("unsigned "), it.pp ]);
+  top.mangledName = "unsigned_" ++ it.mangledName;
   top.integerPromotionsBuiltin = 
     case it of
     | charType() -> signedType(intType())
@@ -135,6 +142,7 @@ top::BuiltinType ::= it::IntegerType
 {
   propagate host;
   top.pp = concat([ text("_Complex "), it.pp ]);
+  top.mangledName = "complexinteger_" ++ it.mangledName;
   top.integerPromotionsBuiltin = 
     complexIntegerType(
       case it of
@@ -149,13 +157,14 @@ top::BuiltinType ::= it::IntegerType
 
 
 {-- Floating types, for which there is a normal and complex variant -}
-nonterminal RealType with pp, host<RealType>;
+nonterminal RealType with pp, host<RealType>, mangledName;
 
 abstract production floatType
 top::RealType ::=
 {
   propagate host;
   top.pp = text("float");
+  top.mangledName = "float";
 }
 
 abstract production doubleType
@@ -163,6 +172,7 @@ top::RealType ::=
 {
   propagate host;
   top.pp = text("double");
+  top.mangledName = "double";
 }
 
 abstract production longdoubleType
@@ -170,11 +180,12 @@ top::RealType ::=
 {
   propagate host;
   top.pp = text("long double");
+  top.mangledName = "longdouble";
 }
 
 
 {-- Integer types, for which there is a signed and unsigned variant -}
-nonterminal IntegerType with pp, host<IntegerType>, integerConversionRank;
+nonterminal IntegerType with pp, host<IntegerType>, mangledName, integerConversionRank;
 
 synthesized attribute integerConversionRank :: Integer;
 
@@ -183,6 +194,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("char");
+  top.mangledName = "char";
   top.integerConversionRank = 0;
 }
 
@@ -191,6 +203,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("short");
+  top.mangledName = "short";
   top.integerConversionRank = 1;
 }
 
@@ -199,6 +212,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("int");
+  top.mangledName = "int";
   top.integerConversionRank = 2;
 }
 
@@ -207,6 +221,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("long");
+  top.mangledName = "long";
   top.integerConversionRank = 3;
 }
 
@@ -215,6 +230,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("long long");
+  top.mangledName = "longlong";
   top.integerConversionRank = 4;
 }
 
@@ -223,6 +239,7 @@ top::IntegerType ::=
 {
   propagate host;
   top.pp = text("__int128");
+  top.mangledName = "int128";
   top.integerConversionRank = 5;
 }
 

--- a/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
@@ -126,10 +126,14 @@ concrete productions top::TypeNames_c
 | 
     { top.ast = ast:nilTypeName(); }
 
--- Ugly hack to allow a close paren after TypeNames_c
+-- Ugly hack to allow a close paren or greater than sign after TypeNames_c
 terminal TypeNames_NEVER_t 'TypeNames_NEVER_t!!!nevernever1234567890' ;
 concrete productions top::Expr_c
 | 'TypeNames_NEVER_t!!!nevernever1234567890' TypeNames_c ')'
+    { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
+        "Placeholder for TypeNames_c should not appear in the tree.") ],
+        location=top.location ) ; }
+| 'TypeNames_NEVER_t!!!nevernever1234567890' TypeNames_c '>'
     { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
         "Placeholder for TypeNames_c should not appear in the tree.") ],
         location=top.location ) ; }

--- a/edu.umn.cs.melt.ableC/hosts/default/Host.sv
+++ b/edu.umn.cs.melt.ableC/hosts/default/Host.sv
@@ -1,0 +1,8 @@
+grammar edu:umn:cs:melt:ableC:host;
+
+imports edu:umn:cs:melt:ableC:concretesyntax as cst;
+
+parser ablecParser :: cst:Root {
+  edu:umn:cs:melt:ableC:concretesyntax;
+}
+

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
@@ -85,17 +85,6 @@ top::Type ::=
   top.rBinaryEqProd = top.lBinaryEqProd;
   
   top.lAssignProd = just(assignString(_, _, location=_));
-  top.rAssignProd = 
-    case top.otherType of
-      pointerType(_, builtinType(_, signedType(charType()))) ->
-        just(
-          binaryOpExpr(
-            _,
-            assignOp(eqOp(location=builtIn()), location=builtIn()),
-            _,
-            location=_))
-    | _ -> nothing()
-    end;
     
   top.subscriptProd = just(subscriptString(_, _, location=_));
   top.subscriptAssignProd = just(subscriptAssignString(_, _, _, _, location=_));
@@ -129,7 +118,7 @@ top::Type ::= quals::[Qualifier] sub::Type
   top.strProd =
     case sub.pointerStrProd of
       just(prod) -> just(prod)
-    | nothing() -> just(showPointer(_, location=_))
+    | nothing() -> just(strPointer(_, location=_))
     end;
 }
 
@@ -202,8 +191,8 @@ top::BuiltinType ::= sub::IntegerType
 aspect production errorType
 top::Type ::=
 {
-  top.showProd = just(\e::Expr l::Location -> errorExpr([], location=l));
-  top.pointerShowProd = just(\e::Expr l::Location -> errorExpr([], location=l));
-  top.strProd = just(\e::Expr l::Location -> errorExpr([], location=l));
-  top.pointerStrProd = just(\e::Expr l::Location -> errorExpr([], location=l));
+  top.showProd = just(\e::Expr l::Location -> errorExpr([err(builtin, "show on errorType")], location=l));
+  top.pointerShowProd = just(\e::Expr l::Location -> errorExpr([err(builtin, "pointer show on errorType")], location=l));
+  top.strProd = just(\e::Expr l::Location -> errorExpr([err(builtin, "str on errorType")], location=l));
+  top.pointerStrProd = just(\e::Expr l::Location -> errorExpr([err(builtin, "pointer str on errorType")], location=l));
 }

--- a/extensions/string/example1.xc
+++ b/extensions/string/example1.xc
@@ -84,5 +84,17 @@ int main(int argc, char **argv) {
   if (m != "\"\\\"abcd\\\\n\\\\n\\\\\\\\\\\"\"")
     return 14;
 
+  int x;
+  int *y = &x;
+  
+  string n = show(y);
+  printf("n: %s\n", n);
+  string o = str(y);
+  printf("o: %s\n", o);
+  string p = show(&y);
+  printf("p: %s\n", p);
+  string q = str(&y);
+  printf("q: %s\n", q);
+
   return 0;
 }

--- a/extensions/string/example1.xc
+++ b/extensions/string/example1.xc
@@ -71,8 +71,18 @@ int main(int argc, char **argv) {
 
   string k = str("abcd");
   printf("k: %s\n", k);
-  if (k != "\"abcd\"")
+  if (k != "abcd")
     return 12;
+
+  string l = show("abcd");
+  printf("l: %s\n", l);
+  if (l != "\"abcd\"")
+    return 13;
+
+  string m = show(show("abcd\n\n\\"));
+  printf("m: %s\n", m);
+  if (m != "\"\\\"abcd\\\\n\\\\n\\\\\\\\\\\"\"")
+    return 14;
 
   return 0;
 }

--- a/extensions/string/example4-type-errors.xc
+++ b/extensions/string/example4-type-errors.xc
@@ -9,5 +9,9 @@ int main(int argc, char **argv) {
   string a = str((t){4});
   string b = 4 * "q";
 
+  b.substring("a");
+
+  char *b = a;
+
   return 0;
 }

--- a/extensions/string/include/string.xh
+++ b/extensions/string/include/string.xh
@@ -10,9 +10,52 @@
 
 // These functions are in theory OK to call directly
 static inline string showString(string s) {
-  string result = GC_malloc(strlen(s) + 3);
-  sprintf((char*)result, "\"%s\"", s);
-  return result;
+  const char *input = (const char*)s;
+  char *result = GC_malloc(2 * strlen(s) + 3); // Worst-case, if all chars are escaped
+  result[0] = '\"';
+  size_t resultIndex = 1;
+  for (size_t i = 0; i < s.length; i++) {
+    char *tmp;
+    switch (input[i]) {
+    case '\a':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 'a';
+      break;
+    case '\b':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 'b';
+      break;
+    case '\n':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 'n';
+      break;
+    case '\r':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 'r';
+      break;
+    case '\t':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 't';
+      break;
+    case '\v':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = 'v';
+      break;
+    case '\"':
+    case '\'':
+    case '\\':
+    case '\?':
+      result[resultIndex++] = '\\';
+      result[resultIndex++] = input[i];
+      break;
+    default:
+      result[resultIndex++] = input[i];
+    }
+  }
+  result[resultIndex++] = '\"';
+  result[resultIndex++] = '\0';
+  
+  return (string)result;
 }
 
 static inline string showInt(int i) {
@@ -47,15 +90,15 @@ static inline string _showPointer(const char *baseTypeName, void *ptr) {
   return (string)result;
 }
 
-static inline void _check_index_string(string s, int i) {
-  int len = s.length;
+static inline void _check_index_string(string s, size_t i) {
+  size_t len = s.length;
   if (i < 0 || i >= len) {
-    fprintf(stderr, "String index out of bounds: length %d, index %d", len, i);
+    fprintf(stderr, "String index out of bounds: length %lu, index %lu", len, i);
     exit(1);
   }
 }
 
-static inline char _index_string(string s, int i) {
+static inline char _index_string(string s, size_t i) {
   _check_index_string(s, i);
   return ((char*)s)[i];
 }
@@ -71,19 +114,19 @@ static inline string _append_string(string s1, string s2) {
   return result;
 }
 
-static inline string _repeat_string(string s, int num) {
+static inline string _repeat_string(string s, size_t num) {
   char *result = GC_malloc(strlen(s) * num + 1);
   result[0] = '\0';
-  int i;
-  for (int i = 0; i < num; i++)
+  size_t i;
+  for (size_t i = 0; i < num; i++)
     strcat(result, s);
   return (string)result;
 }
 
 static inline string _remove_string(string s1, string s2) {
-  int i, j;
-  int len1 = strlen(s1);
-  int len2 = strlen(s2);
+  size_t i, j;
+  size_t len1 = strlen(s1);
+  size_t len2 = strlen(s2);
   char *result = GC_malloc(strlen(s1) + 1);
   for (i = 0, j = 0; i < len1; i++) {
     if (i > len1 - len2 || strncmp((const char*)s1 + i, s2, len2)) {
@@ -99,10 +142,10 @@ static inline string _remove_string(string s1, string s2) {
   return (string)result;
 }
 
-static inline string _substring(string s, int start, int end) {
-  int len = s.length;
+static inline string _substring(string s, size_t start, size_t end) {
+  size_t len = s.length;
   if (start < 0 || start >= len || end < 0 || end >= len || start > end) {
-    fprintf(stderr, "Substring index out of bounds: length %d, start %d, end %d", len, start, end);
+    fprintf(stderr, "Substring index out of bounds: length %lu, start %lu, end %lu", len, start, end);
     exit(1);
   }
   char *result = GC_malloc(end - start + 1);

--- a/extensions/string/include/string.xh
+++ b/extensions/string/include/string.xh
@@ -11,7 +11,7 @@
 // These functions are in theory OK to call directly
 static inline string showString(string s) {
   const char *input = (const char*)s;
-  char *result = GC_malloc(2 * strlen(s) + 3); // Worst-case, if all chars are escaped
+  char *result = GC_malloc(2 * strlen(s) + 3); // Worst-case size, if all chars are escaped
   result[0] = '\"';
   size_t resultIndex = 1;
   for (size_t i = 0; i < s.length; i++) {
@@ -83,9 +83,15 @@ static inline string strChar(char c) {
   return (string)result;
 }
 
+static inline string strPointer(void *ptr) {
+  char *result = GC_malloc(9);
+  sprintf(result, "%lx", (unsigned long)ptr);
+  return (string)result;
+}
+
 // Helper functions should really only be used through the extension
 static inline string _showPointer(const char *baseTypeName, void *ptr) {
-  char *result = GC_malloc(strlen(baseTypeName) + 10);
+  char *result = GC_malloc(strlen(baseTypeName) + 17);
   sprintf(result, "<%s at 0x%lx>", baseTypeName, (unsigned long)ptr);
   return (string)result;
 }

--- a/extensions/vector/README.md
+++ b/extensions/vector/README.md
@@ -2,19 +2,27 @@ Vector extension
 ================
 
 This extension provides a nice vector list representation, similar to vectors in C++.  
-Vectors are type-generic with erasure (for now).  Operator overloading is provided for basic operations such as append.  
-Integration with the string extension is also provided to give a tostring for vectors that have tostring sub types.  
+Vectors are implemented as a garbage-collected pointer to a templated struct, containing a garbage-collected array of elements.
+Operator overloading is provided for basic operations such as append.  
+Integration with the string extension is also provided to implement show for vectors that have showable sub types.
+
+Vectors can be constructed in multiple ways:
+| Name                    | Example |
+| ----------------------- | ------- |
+| Initialized constructor | vector<int> v = vec<int>[1, 2, 3, 4]; |
+| Size constructor        | vector<int> v = vec<int>(8); |
+| Copy constructor        | vector<int> v = copy_vector(v1); |
 
 Overloaded operators include
-* Append: v1 + v2
-* Equality: v1 == v2
-* Subscript: v[i]
-* Subsctipt assign: v[i] = x
-* To string operator: tostring(x)
+| Name                    | Example |
+| ----------------------- | ------- |
+| Append                  | v1 + v2 |
+| Update assign           | v1 += v2 |
+| Equality                | v1 == v2 |
+| Subscript               | v[i] |
+| Subscript assign        | v[i] = x |
+| Show operator           | show(x) |
 
 TODO items:
-* Struct container should be passed directly, not as an allocated pointer
-* Handle generic types the right way
- * Need to implement some notion of 'templates' like in C++, probably needs to be baked into ableC.  Somehow generate a custom implementation struct and implementation functions for every instantiated type
- * Add support for generic type parameters to the ableC type checker
- * Type classes?  Probably not needed but requires some thought
+* Instead of allocating the contents pointer seperately, it could instead be set to point to itself so that the entire vector is stored in a single block of memory.  
+* Figure out a better way of doing templating to replace explicit ASTs of lifted functions

--- a/extensions/vector/README.md
+++ b/extensions/vector/README.md
@@ -2,7 +2,7 @@ Vector extension
 ================
 
 This extension provides a nice vector list representation, similar to vectors in C++.  
-Vectors are implemented as a garbage-collected pointer to a templated struct, containing a garbage-collected array of elements.
+Vectors are implemented as a garbage-collected pointer to a templated struct, containing a garbage-collected array of elements.  Due to our current implementation of lifting/templating, typedef'ed template parameters must be declared globally.  
 Operator overloading is provided for basic operations such as append.  
 Integration with the string extension is also provided to implement show for vectors that have showable sub types.
 

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
@@ -2,4 +2,5 @@ grammar edu:umn:cs:melt:exts:ableC:vector;
 
 exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
 exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
+
 exports edu:umn:cs:melt:exts:ableC:vector:abstractsyntax;

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/Exports.sv
@@ -2,5 +2,6 @@ grammar edu:umn:cs:melt:exts:ableC:vector;
 
 exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
 exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
+exports edu:umn:cs:melt:exts:ableC:vector:concretesyntax:copyConstructor;
 
 exports edu:umn:cs:melt:exts:ableC:vector:abstractsyntax;

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -50,7 +50,12 @@ function vectorTypedefGlobalDecls
 abstract production vectorTypeExpr 
 top::BaseTypeExpr ::= sub::TypeName
 {
-  forwards to directTypeExpr(vectorType([], sub.typerep));
+  sub.env = globalEnv(top.env);
+  
+  forwards to
+    if !null(sub.errors)
+    then errorTypeExpr(sub.errors)
+    else directTypeExpr(vectorType([], sub.typerep));
 }
 
 abstract production vectorType

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -77,7 +77,6 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
   
-  -- TODO
   top.ovrld:lBinaryEqProd =
     case top.ovrld:otherType of
       vectorType(_, s) ->

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -1,5 +1,6 @@
 grammar edu:umn:cs:melt:exts:ableC:vector:abstractsyntax;
 
+ -- TODO: Template this instead, someday
 function vectorTypedefGlobalDecls
 [Pair<String Decl>] ::= sub::Type
 {
@@ -88,12 +89,12 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
   
-  -- TODO
   top.ovrld:memberProd =
     case top.ovrld:otherName of
-      "length"   -> just(memberExpr(_, true, name("length", location=builtin), location=_))
-    | "size"     -> just(memberExpr(_, true, name("length", location=builtin), location=_))
-    | "capacity" -> just(memberExpr(_, true, name("capacity", location=builtin), location=_))
+      "length"   -> just(lengthVector(_, location=_))
+    | "size"     -> just(lengthVector(_, location=_))
+    | "capacity" -> just(capacityVector(_, location=_))
+    | "elem_size" -> just(elemSizeVector(_, location=_))
     | _ -> nothing()
     end;
   

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -56,7 +56,7 @@ top::BaseTypeExpr ::= sub::TypeName
 abstract production vectorType
 top::Type ::= qs::[Qualifier] sub::Type
 {
-  top.lpp = pp"${ppImplode(space(), map((.pp), qs))} vector(${sub.lpp}${sub.rpp})";
+  top.lpp = pp"${ppImplode(space(), map((.pp), qs))}vector<${sub.lpp}${sub.rpp}>";
   top.rpp = pp"";
 
   top.ovrld:lBinaryPlusProd =

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -7,20 +7,20 @@ function vectorTypedefGlobalDecls
     [pair(
       "_vector_" ++ sub.mangledName,
       typedefDecls(
-        [gccAttribute(
-          consAttrib(
-            appliedAttrib(
-              attribName(name("refId", location=builtin)),
-              consExpr(
-                stringLiteral(
-                  s"\"edu:umn:cs:melt:exts:ableC:vector:_vector_${sub.mangledName}_s\"",
-                  location=builtin),
-                nilExpr())),
-            nilAttrib()))],
+        [],
         structTypeExpr(
           [],
           structDecl(
-            [],
+            [gccAttribute(
+               consAttrib(
+                 appliedAttrib(
+                   attribName(name("refId", location=builtin)),
+                   consExpr(
+                     stringLiteral(
+                       s"\"edu:umn:cs:melt:exts:ableC:vector:_vector_${sub.mangledName}_s\"",
+                       location=builtin),
+                     nilExpr())),
+                 nilAttrib()))],
             justName(name("_vector_" ++ sub.mangledName ++ "_s", location=builtin)),
             consStructItem(
               structItem(
@@ -58,8 +58,9 @@ top::Type ::= qs::[Qualifier] sub::Type
   top.lpp = pp"${ppImplode(space(), map((.pp), qs))} vector(${sub.lpp}${sub.rpp})";
   top.rpp = pp"";
 
-  top.lBinaryPlusProd =
-    case top.otherType of
+  -- TODO
+  top.ovrld:lBinaryPlusProd =
+    case top.ovrld:otherType of
       vectorType(_, s) ->
         if compatibleTypes(sub, s, true)
         then just(appendVector(_, _, location=_))
@@ -67,8 +68,9 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
     
-  top.lAssignPlusProd =
-    case top.otherType of
+  -- TODO
+  top.ovrld:lAssignPlusProd =
+    case top.ovrld:otherType of
       vectorType(_, s) ->
         if compatibleTypes(sub, s, true)
         then just(appendAssignVector(_, _, location=_))
@@ -76,8 +78,9 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
   
-  top.lBinaryEqProd =
-    case top.otherType of
+  -- TODO
+  top.ovrld:lBinaryEqProd =
+    case top.ovrld:otherType of
       vectorType(_, s) ->
         if compatibleTypes(sub, s, true)
         then just(eqVector(_, _, location=_))
@@ -85,23 +88,24 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
   
-  top.memberProd =
-    case top.otherName of
+  -- TODO
+  top.ovrld:memberProd =
+    case top.ovrld:otherName of
       "length"   -> just(memberExpr(_, true, name("length", location=builtin), location=_))
     | "size"     -> just(memberExpr(_, true, name("length", location=builtin), location=_))
     | "capacity" -> just(memberExpr(_, true, name("capacity", location=builtin), location=_))
     | _ -> nothing()
     end;
-    
-  top.subscriptProd =
-    case top.otherType of
+  
+  top.ovrld:subscriptProd =
+    case top.ovrld:otherType of
       builtinType(_, signedType(_)) -> just(subscriptVector(_, _, location=_))
     | builtinType(_, unsignedType(_)) -> just(subscriptVector(_, _, location=_))
     | _ -> nothing()
     end;
-    
-  top.subscriptAssignProd =
-    case top.otherType, top.otherType2 of
+  
+  top.ovrld:subscriptAssignProd =
+    case top.ovrld:otherType, top.ovrld:otherType2 of
       builtinType(_, signedType(_)), s ->
         if compatibleTypes(sub, s, true)
         then just(subscriptAssignVector(_, _, _, _, location=_))
@@ -113,6 +117,7 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _, _ -> nothing()
     end;
   
+  -- TODO
   top.showProd =
     case sub.showProd of
       just(_) -> just(showVector(_, location=_))

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -59,7 +59,6 @@ top::Type ::= qs::[Qualifier] sub::Type
   top.lpp = pp"${ppImplode(space(), map((.pp), qs))} vector(${sub.lpp}${sub.rpp})";
   top.rpp = pp"";
 
-  -- TODO
   top.ovrld:lBinaryPlusProd =
     case top.ovrld:otherType of
       vectorType(_, s) ->
@@ -69,7 +68,6 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _ -> nothing()
     end;
     
-  -- TODO
   top.ovrld:lAssignPlusProd =
     case top.ovrld:otherType of
       vectorType(_, s) ->

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Type.sv
@@ -115,7 +115,6 @@ top::Type ::= qs::[Qualifier] sub::Type
     | _, _ -> nothing()
     end;
   
-  -- TODO
   top.showProd =
     case sub.showProd of
       just(_) -> just(showVector(_, location=_))

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
@@ -79,24 +79,28 @@ Stmt ::= n::String sub::Type size::Expr
 abstract production initVector
 top::Expr ::= sub::TypeName size::Expr
 {
-  forwards to
+  local fwrd::Expr =
     stmtExpr(
       mkInitVectorStmt("_vec", sub.typerep, size),
       declRefExpr(name("_vec", location=builtin), location=builtin),
       location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production constructVector
 top::Expr ::= sub::TypeName e::Exprs
 {
   e.argumentPosition = 0;
-  forwards to 
+  local fwrd::Expr =
     stmtExpr(
       seqStmt(
         mkInitVectorStmt("_vec", sub.typerep, mkIntConst(e.count, builtin)),
         e.vectorInitTrans),
       declRefExpr(name("_vec", location=builtin), location=top.location),
       location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 synthesized attribute vectorInitTrans::Stmt occurs on Exprs;
@@ -207,7 +211,7 @@ top::Expr ::= e::Expr
             returnStmt(
               justExpr(declRefExpr(name("result", location=builtin), location=builtin)))]))))];
 
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       globalDecls,
       directCallExpr(
@@ -215,6 +219,8 @@ top::Expr ::= e::Expr
         consExpr(e, nilExpr()),
         location=builtin),
       location=builtin);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 -- Vector append
@@ -229,7 +235,7 @@ top::Expr ::= e1::Expr e2::Expr
     
   local vecTempName::String = "_vec_" ++ toString(genInt());
   
-  forwards to
+  local fwrd::Expr =
     stmtExpr(
       mkDecl(vecTempName, vectorType([], subType), copyVector(e1, location=builtin), builtin),
       appendAssignVector(
@@ -237,6 +243,8 @@ top::Expr ::= e1::Expr e2::Expr
         e2,
         location=builtin),
       location=builtin);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production appendAssignVector
@@ -342,7 +350,7 @@ top::Expr ::= e1::Expr e2::Expr
             returnStmt(
               justExpr(declRefExpr(name("vec1", location=builtin), location=builtin)))]))))];
 
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       globalDecls,
       directCallExpr(
@@ -350,6 +358,8 @@ top::Expr ::= e1::Expr e2::Expr
         consExpr(e1, consExpr(e2, nilExpr())),
         location=builtin),
       location=builtin);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production eqVector
@@ -450,7 +460,7 @@ top::Expr ::= e1::Expr e2::Expr
                 returnStmt(justExpr(mkIntConst(0, builtin))))),
             returnStmt(justExpr(mkIntConst(1, builtin)))]))))];
 
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       globalDecls,
       directCallExpr(
@@ -458,6 +468,8 @@ top::Expr ::= e1::Expr e2::Expr
         consExpr(e1, consExpr(e2, nilExpr())),
         location=builtin),
       location=builtin);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production lengthVector
@@ -469,7 +481,7 @@ top::Expr ::= e::Expr
     | _ -> error("lengthVector where lhs is non-vector")
     end;
     
-  forwards to 
+  local fwrd::Expr =
     injectGlobalDecls(
       vectorTypedefGlobalDecls(subType),
       memberExpr(
@@ -478,6 +490,8 @@ top::Expr ::= e::Expr
         name("length", location=builtin),
         location=builtin),
       location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production capacityVector
@@ -489,7 +503,7 @@ top::Expr ::= e::Expr
     | _ -> error("capacityVector where lhs is non-vector")
     end;
     
-  forwards to 
+  local fwrd::Expr =
     injectGlobalDecls(
       vectorTypedefGlobalDecls(subType),
       memberExpr(
@@ -498,6 +512,8 @@ top::Expr ::= e::Expr
         name("capacity", location=builtin),
         location=builtin),
       location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production elemSizeVector
@@ -509,7 +525,7 @@ top::Expr ::= e::Expr
     | _ -> error("elemSizeVector where lhs is non-vector")
     end;
     
-  forwards to 
+  local fwrd::Expr =
     injectGlobalDecls(
       vectorTypedefGlobalDecls(subType),
       memberExpr(
@@ -518,6 +534,8 @@ top::Expr ::= e::Expr
         name("elem_size", location=builtin),
         location=builtin),
       location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
 }
 
 abstract production subscriptVector
@@ -532,7 +550,7 @@ top::Expr ::= e1::Expr e2::Expr
   local vecTempName::String = "_vec_" ++ toString(genInt());
   local indexTempName::String = "_index_" ++ toString(genInt());
 
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       vectorTypedefGlobalDecls(subType),
         stmtExpr(
@@ -568,6 +586,8 @@ top::Expr ::= e1::Expr e2::Expr
             location=builtin),
           location=top.location),
         location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_check_index_vector", top.location, top.env), fwrd);
 }
 
 abstract production subscriptAssignVector
@@ -582,7 +602,7 @@ top::Expr ::= lhs::Expr index::Expr op::AssignOp rhs::Expr
   local vecTempName::String = "_vec_" ++ toString(genInt());
   local indexTempName::String = "_index_" ++ toString(genInt());
   
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       vectorTypedefGlobalDecls(subType),
         stmtExpr(
@@ -631,6 +651,8 @@ top::Expr ::= lhs::Expr index::Expr op::AssignOp rhs::Expr
               location=builtin),
           location=top.location),
         location=top.location);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_maybe_grow_vector_by_one", top.location, top.env), fwrd);
 }
 
 abstract production showVector
@@ -745,7 +767,7 @@ top::Expr ::= e::Expr
                   stringLiteral("\"]\"", location=builtin),
                   location=builtin)))]))))];
   
-  forwards to
+  local fwrd::Expr =
     injectGlobalDecls(
       globalDecls,
       directCallExpr(
@@ -753,4 +775,16 @@ top::Expr ::= e::Expr
         consExpr(e, nilExpr()),
         location=builtin),
       location=builtin);
+  
+  forwards to mkErrorCheck(checkVectorHeaderDef("_init_vector", top.location, top.env), fwrd);
+}
+
+-- Check the given env for the given function name
+function checkVectorHeaderDef
+[Message] ::= n::String loc::Location env::Decorated Env
+{
+  return
+    if !null(lookupValue(n, env))
+    then []
+    else [err(loc, "Missing include of vector.xh")];
 }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
@@ -14,16 +14,16 @@ imports edu:umn:cs:melt:exts:ableC:string;
 global builtin::Location = builtinLoc("vector");
 
 -- Vector initialization
-function initVectorStmts
-Stmt ::= sub::TypeName size::Expr
+function mkInitVectorStmt
+Stmt ::= n::String sub::Type size::Expr
 {
   return
     injectGlobalDeclsStmt(
-      vectorTypedefGlobalDecls(sub.typerep),
+      vectorTypedefGlobalDecls(sub),
       seqStmt(
         mkDecl(
-          "_vec",
-          vectorType([], sub.typerep),
+          n,
+          vectorType([], sub),
           directCallExpr(
             name("GC_malloc", location=builtin),
             consExpr(
@@ -36,8 +36,8 @@ Stmt ::= sub::TypeName size::Expr
                         [],
                         refIdTagType(
                           structSEU(),
-                          "_vector_" ++ sub.typerep.mangledName ++ "_s",
-                          "edu:umn:cs:melt:exts:ableC:vector:_vector_" ++ sub.typerep.mangledName ++ "_s"))),
+                          "_vector_" ++ sub.mangledName ++ "_s",
+                          "edu:umn:cs:melt:exts:ableC:vector:_vector_" ++ sub.mangledName ++ "_s"))),
                     baseTypeExpr())),
                 location=builtin),
               nilExpr()),
@@ -49,7 +49,7 @@ Stmt ::= sub::TypeName size::Expr
             consExpr(
               mkAddressOf(
                 memberExpr(
-                  declRefExpr(name("_vec", location=builtin), location=builtin),
+                  declRefExpr(name(n, location=builtin), location=builtin),
                   true,
                   name("_info", location=builtin),
                   location=builtin),
@@ -61,7 +61,7 @@ Stmt ::= sub::TypeName size::Expr
                     pointerTypeExpr([], pointerTypeExpr([], baseTypeExpr()))),
                   mkAddressOf(
                     memberExpr(
-                      declRefExpr(name("_vec", location=builtin), location=builtin),
+                      declRefExpr(name(n, location=builtin), location=builtin),
                       true,
                       name("_contents", location=builtin),
                       location=builtin),
@@ -70,7 +70,7 @@ Stmt ::= sub::TypeName size::Expr
                 consExpr(
                   unaryExprOrTypeTraitExpr(
                     sizeofOp(location=builtin),
-                    typeNameExpr(sub),
+                    typeNameExpr(typeName(directTypeExpr(sub), baseTypeExpr())),
                     location=builtin),
                   consExpr(size, nilExpr())))),
           location=builtin))));
@@ -81,7 +81,7 @@ top::Expr ::= sub::TypeName size::Expr
 {
   forwards to
     stmtExpr(
-      initVectorStmts(sub, size),
+      mkInitVectorStmt("_vec", sub.typerep, size),
       declRefExpr(name("_vec", location=builtin), location=builtin),
       location=top.location);
 }
@@ -93,7 +93,7 @@ top::Expr ::= sub::TypeName e::Exprs
   forwards to 
     stmtExpr(
       seqStmt(
-        initVectorStmts(sub, mkIntConst(e.count, builtin)),
+        mkInitVectorStmt("_vec", sub.typerep, mkIntConst(e.count, builtin)),
         e.vectorInitTrans),
       declRefExpr(name("_vec", location=builtin), location=top.location),
       location=top.location);
@@ -107,12 +107,10 @@ top::Exprs ::= h::Expr t::Exprs
   top.vectorInitTrans =
     seqStmt(
       exprStmt(
-        ovrld:binaryOpExpr(
-          ovrld:arraySubscriptExpr(
-            declRefExpr(name("_vec", location=builtin), location=builtin),
-            mkIntConst(top.argumentPosition, builtin),
-            location=builtin),
-          assignOp(eqOp(location=builtin), location=builtin),
+        subscriptAssignVector(
+          declRefExpr(name("_vec", location=builtin), location=builtin),
+          mkIntConst(top.argumentPosition, builtin),
+          eqOp(location=builtin),
           h,
           location=builtin)),
       t.vectorInitTrans);
@@ -122,6 +120,102 @@ aspect production nilExpr
 top::Exprs ::= 
 {
   top.vectorInitTrans = nullStmt();
+}
+
+abstract production copyVector
+top::Expr ::= e::Expr
+{
+  local subType::Type = 
+    case e.typerep of
+      vectorType(_, s) -> s
+    | _ -> error("copyVector where lhs is non-vector")
+    end;
+  
+  local subscriptFunName::String = "_copy_vector_" ++ subType.mangledName;
+
+  local globalDecls::[Pair<String Decl>] = -- TODO: Template this instead, someday
+    vectorTypedefGlobalDecls(subType) ++
+    [pair(
+      subscriptFunName,
+      functionDeclaration(
+        functionDecl(
+          [staticStorageClass()],
+          [],
+          directTypeExpr(vectorType([], subType)),
+          functionTypeExprWithArgs(
+            baseTypeExpr(),
+            consParameters(
+              parameterDecl(
+                [],
+                vectorTypeExpr(typeName(directTypeExpr(subType), baseTypeExpr())),
+                baseTypeExpr(),
+                justName(name("vec", location=builtin)),
+                []),
+              nilParameters()),
+            false),
+          name(subscriptFunName, location=builtin),
+          [],
+          nilDecl(),
+          foldStmt([
+            mkInitVectorStmt(
+              "result",
+              subType,
+              lengthVector(
+                declRefExpr(name("vec", location=builtin), location=builtin),
+                location=builtin)),
+            seqStmt(
+              declStmt( 
+                variableDecls(
+                  [], [],
+                  typedefTypeExpr([], name("size_t", location=builtin)),
+                  consDeclarator( 
+                    declarator(
+                      name("i", location=builtin),
+                      baseTypeExpr(),
+                      [], 
+                      nothingInitializer()) , 
+                    nilDeclarator()))),
+              forStmt(
+                justExpr(
+                  binaryOpExpr(
+                    declRefExpr(name("i", location=builtin), location=builtin),
+                    assignOp(eqOp(location=builtin), location=builtin),
+                    mkIntConst(0, builtin),
+                    location=builtin)),
+                justExpr(
+                  binaryOpExpr(
+                    declRefExpr(name("i", location=builtin), location=builtin),
+                    compareOp(ltOp(location=builtin), location=builtin),
+                    lengthVector(
+                      declRefExpr(name("vec", location=builtin), location=builtin),
+                      location=builtin),
+                    location=builtin)),
+                justExpr(
+                  unaryOpExpr(
+                    postIncOp(location=builtin),
+                    declRefExpr(name("i", location=builtin), location=builtin),
+                    location=builtin)),
+                exprStmt(
+                  subscriptAssignVector(
+                    declRefExpr(name("result", location=builtin), location=builtin),
+                    declRefExpr(name("i", location=builtin), location=builtin),
+                    eqOp(location=builtin),
+                    subscriptVector(
+                      declRefExpr(name("vec", location=builtin), location=builtin),
+                      declRefExpr(name("i", location=builtin), location=builtin),
+                      location=builtin),
+                    location=builtin)))),
+            returnStmt(
+              justExpr(declRefExpr(name("vec", location=builtin), location=builtin)))]))))];
+
+  forwards to
+    injectGlobalDecls(
+      globalDecls,
+      directCallExpr(
+        name(subscriptFunName, location=builtin),
+        consExpr(e, nilExpr()),
+        location=builtin),
+      location=builtin);
 }
 
 -- Vector append
@@ -246,6 +340,66 @@ top::Expr ::= e1::Expr e2::Expr
       location=top.location);
 }
 
+abstract production lengthVector
+top::Expr ::= e::Expr
+{
+  local subType::Type = 
+    case e.typerep of
+      vectorType(_, s) -> s
+    | _ -> error("lengthVector where lhs is non-vector")
+    end;
+    
+  forwards to 
+    injectGlobalDecls(
+      vectorTypedefGlobalDecls(subType),
+      memberExpr(
+        memberExpr(e, true, name("_info", location=builtin), location=builtin),
+        false,
+        name("length", location=builtin),
+        location=builtin),
+      location=top.location);
+}
+
+abstract production capacityVector
+top::Expr ::= e::Expr
+{
+  local subType::Type = 
+    case e.typerep of
+      vectorType(_, s) -> s
+    | _ -> error("capacityVector where lhs is non-vector")
+    end;
+    
+  forwards to 
+    injectGlobalDecls(
+      vectorTypedefGlobalDecls(subType),
+      memberExpr(
+        memberExpr(e, true, name("_info", location=builtin), location=builtin),
+        false,
+        name("capacity", location=builtin),
+        location=builtin),
+      location=top.location);
+}
+
+abstract production elemSizeVector
+top::Expr ::= e::Expr
+{
+  local subType::Type = 
+    case e.typerep of
+      vectorType(_, s) -> s
+    | _ -> error("elemSizeVector where lhs is non-vector")
+    end;
+    
+  forwards to 
+    injectGlobalDecls(
+      vectorTypedefGlobalDecls(subType),
+      memberExpr(
+        memberExpr(e, true, name("_info", location=builtin), location=builtin),
+        false,
+        name("elem_size", location=builtin),
+        location=builtin),
+      location=top.location);
+}
+
 abstract production subscriptVector
 top::Expr ::= e1::Expr e2::Expr
 {
@@ -254,78 +408,26 @@ top::Expr ::= e1::Expr e2::Expr
       vectorType(_, s) -> s
     | _ -> error("subscriptVector where lhs is non-vector")
     end;
-    
-  local subscriptFunName::String = "_index_vector_" ++ subType.mangledName;
-
-  local globalDecls::[Pair<String Decl>] =
-    vectorTypedefGlobalDecls(subType) ++
-    [pair(
-       subscriptFunName,
-       functionDeclaration(
-         functionDecl(
-           [staticStorageClass()],
-           [],
-           directTypeExpr(subType),--
-           functionTypeExprWithArgs(
-             baseTypeExpr(),
-             consParameters(
-               parameterDecl(
-                 [],
-                 vectorTypeExpr(typeName(directTypeExpr(subType), baseTypeExpr())),
-                 baseTypeExpr(),
-                 justName(name("vec", location=builtin)),
-                 []),
-               consParameters(
-                 parameterDecl(
-                   [],
-                   typedefTypeExpr([], name("size_t", location=builtin)),
-                   baseTypeExpr(),
-                   justName(name("i", location=builtin)),
-                   []),
-                 nilParameters())),
-             false),
-           name(subscriptFunName, location=builtin),
-           [],
-           nilDecl(),
-           seqStmt(
-             exprStmt(
-               directCallExpr(
-                 name("_check_index_vector", location=builtin),
-                 consExpr(
-                   memberExpr(
-                     declRefExpr(name("vec", location=builtin), location=builtin),
-                     true,
-                     name("_info", location=builtin),
-                     location=builtin),
-                   consExpr(
-                     memberExpr(
-                       declRefExpr(name("vec", location=builtin), location=builtin),
-                       true,
-                       name("_contents", location=builtin),
-                       location=builtin),
-                     consExpr(
-                       declRefExpr(name("i", location=builtin), location=builtin),
-                       nilExpr()))),
-                 location=builtin)),
-             returnStmt(
-               justExpr(
-                 arraySubscriptExpr(
-                   memberExpr(
-                     declRefExpr(name("vec", location=builtin), location=builtin),
-                     true,
-                     name("_contents", location=builtin),
-                     location=builtin),
-                   declRefExpr(name("i", location=builtin), location=builtin),
-                   location=builtin)))))))];
 
   forwards to
     injectGlobalDecls(
-      globalDecls,
-      directCallExpr(
-        name(subscriptFunName, location=builtin),
-        consExpr(e1, consExpr(e2, nilExpr())),
-        location=builtin),
-      location=builtin);
+      vectorTypedefGlobalDecls(subType),
+        stmtExpr(
+          exprStmt(
+            directCallExpr(
+              name("_check_index_vector", location=builtin),
+              consExpr(
+                memberExpr(e1, true, name("_info", location=builtin), location=builtin),
+                consExpr(
+                  memberExpr(e1, true, name("_contents", location=builtin), location=builtin),
+                  consExpr(e2, nilExpr()))),
+              location=top.location)),
+            arraySubscriptExpr(
+              memberExpr(e1, true, name("_contents", location=builtin), location=builtin),
+              e2,
+              location=builtin),
+          location=top.location),
+        location=top.location);
 }
 
 abstract production subscriptAssignVector
@@ -343,11 +445,20 @@ top::Expr ::= lhs::Expr index::Expr op::AssignOp rhs::Expr
         stmtExpr(
           exprStmt(
             directCallExpr(
-              name("_check_index_vector", location=builtin),
+              name("_maybe_grow_vector_by_one", location=builtin),
               consExpr(
-                memberExpr(lhs, true, name("_info", location=builtin), location=builtin),
+                mkAddressOf(
+                  memberExpr(lhs, true, name("_info", location=builtin), location=builtin),
+                  builtin),
                 consExpr(
-                  memberExpr(lhs, true, name("_contents", location=builtin), location=builtin),
+                  explicitCastExpr(
+                    typeName(
+                      directTypeExpr(builtinType([], voidType())),
+                      pointerTypeExpr([], pointerTypeExpr([], baseTypeExpr()))),
+                    mkAddressOf(
+                      memberExpr(lhs, true, name("_contents", location=builtin), location=builtin),
+                      builtin),
+                    location=builtin),
                   consExpr(index, nilExpr()))),
               location=top.location)),
             binaryOpExpr(

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/constructor/Constructor.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/constructor/Constructor.sv
@@ -14,7 +14,18 @@ import edu:umn:cs:melt:exts:ableC:vector;
 import edu:umn:cs:melt:exts:ableC:vector:mda_test;
 
 marking terminal NewVector_t 'new_vector' lexer classes {Ckeyword};
+marking terminal InitVector_t 'init_vector' lexer classes {Ckeyword};
 
 concrete productions top::PrimaryExpr_c
-| 'new_vector' '(' sub::TypeName_c ')' '[' elems::ArgumentExprList_c ']'
-  { top.ast = constructVector(sub.ast, foldExpr(elems.ast), location=top.location); }
+| 'new_vector' '(' sub::TypeName_c ')' elems::VectorConstructorList_c
+  { top.ast = constructVector(sub.ast, elems.ast, location=top.location); }
+| 'init_vector' '(' sub::TypeName_c ')' '(' size::AssignExpr_c ')'
+  { top.ast = initVector(sub.ast, size.ast, location=top.location); }
+
+nonterminal VectorConstructorList_c with location, ast<Exprs>;
+
+concrete productions top::VectorConstructorList_c
+|'[' elems::ArgumentExprList_c ']'
+  { top.ast = foldExpr(elems.ast); }
+|'[' ']'
+  { top.ast = nilExpr(); }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/copyConstructor/CopyConstructor.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/copyConstructor/CopyConstructor.sv
@@ -1,0 +1,20 @@
+grammar edu:umn:cs:melt:exts:ableC:vector:concretesyntax:copyConstructor;
+
+imports edu:umn:cs:melt:ableC:concretesyntax;
+imports silver:langutil only ast;
+
+imports edu:umn:cs:melt:ableC:abstractsyntax;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
+imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+--imports edu:umn:cs:melt:ableC:abstractsyntax:debug;
+
+import edu:umn:cs:melt:exts:ableC:vector;
+
+-- Spurious import, to trigger the tests on build.
+import edu:umn:cs:melt:exts:ableC:vector:mda_test;
+
+marking terminal CopyVector_t 'copy_vector' lexer classes {Ckeyword};
+
+concrete productions top::PrimaryExpr_c
+| 'copy_vector' '(' e::AssignExpr_c ')'
+  { top.ast = copyVector(e.ast, location=top.location); }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/typeExpr/TypeExpr.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/concretesyntax/typeExpr/TypeExpr.sv
@@ -16,6 +16,6 @@ import edu:umn:cs:melt:exts:ableC:vector:mda_test;
 marking terminal Vector_t 'vector' lexer classes {Ckeyword};
 
 concrete productions top::TypeSpecifier_c
-| 'vector' '(' sub::TypeName_c ')'
+| 'vector' '<' sub::TypeName_c '>'
     { top.realTypeSpecifiers = [vectorTypeExpr(sub.ast)];
       top.preTypeSpecifiers = []; }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
@@ -2,9 +2,9 @@ grammar edu:umn:cs:melt:exts:ableC:vector:mda_test;
 
 import edu:umn:cs:melt:ableC:host;
 
---copper_mda testConstructor(ablecParser) {
---  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
---}
+copper_mda testConstructor(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
+}
 
 copper_mda testTypeExpr(ablecParser) {
   edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
@@ -2,10 +2,10 @@ grammar edu:umn:cs:melt:exts:ableC:vector:mda_test;
 
 import edu:umn:cs:melt:ableC:host;
 
---copper_mda testLambdaExpr(ablecParser) {
+--copper_mda testConstructor(ablecParser) {
 --  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
 --}
 
-copper_mda testLambdaExpr(ablecParser) {
+copper_mda testTypeExpr(ablecParser) {
   edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
 }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/mda_test/MDA.sv
@@ -2,10 +2,14 @@ grammar edu:umn:cs:melt:exts:ableC:vector:mda_test;
 
 import edu:umn:cs:melt:ableC:host;
 
+copper_mda testTypeExpr(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
+}
+
 copper_mda testConstructor(ablecParser) {
   edu:umn:cs:melt:exts:ableC:vector:concretesyntax:constructor;
 }
 
-copper_mda testTypeExpr(ablecParser) {
-  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:typeExpr;
+copper_mda testCopyConstructor(ablecParser) {
+  edu:umn:cs:melt:exts:ableC:vector:concretesyntax:copyConstructor;
 }

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -4,15 +4,15 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  //init_vector(int) (2);
-  vector(int) a = new_vector(int) [1, 2, 3];
+  //vec<int>(2);
+  vector<int> a = vec<int> [1, 2, 3];
   printf("%d\n", a[2]);
 
-  /* vector(int) a = new_vector(int) [1, 2, 3]; */
+  /* vector<int> a = vec<int> [1, 2, 3]; */
   /* printf("a: %s\n", show(a)); */
-  /* vector(int) b = new_vector(int) [4, 5, 6]; */
+  /* vector<int> b = vec<int> [4, 5, 6]; */
   /* printf("b: %s\n", show(b)); */
-  /* vector(int) c = a + b; */
+  /* vector<int> c = a + b; */
   /* printf("c: %s\n", show(c)); */
   /* a += b; */
   /* printf("a: %s\n", show(a)); */

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -4,31 +4,31 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  //vec<int>(2);
-  vector<int> a = vec<int> [1, 2, 3];
-  printf("%d\n", a[2]);
+  vector<int> v = vec<int> [1, 2, 3];
+  vector<int> v1 = copy_vector(v);
+  printf("%d\n", v1[2]);
 
-  /* vector<int> a = vec<int> [1, 2, 3]; */
-  /* printf("a: %s\n", show(a)); */
-  /* vector<int> b = vec<int> [4, 5, 6]; */
-  /* printf("b: %s\n", show(b)); */
-  /* vector<int> c = a + b; */
-  /* printf("c: %s\n", show(c)); */
-  /* a += b; */
-  /* printf("a: %s\n", show(a)); */
-  /* b[1] += 7; */
-  /* b[3] = 6; */
-  /* printf("b: %s\n", show(b)); */
-  /* if (a != c) */
-  /*   return 1; */
-  /* if (a == b) */
-  /*   return 2; */
-  /* if (b[1] != 12) */
-  /*   return 3; */
-  /* if (b[3] != 6) */
-  /*   return 4; */
-  /* if (b.length != 4) */
-  /*   return 5; */
+  vector<int> a = vec<int> [1, 2, 3];
+  //printf("a: %s\n", show(a));
+  vector<int> b = vec<int> [4, 5, 6];
+  //printf("b: %s\n", show(b));
+  //vector<int> c = a + b;
+  //printf("c: %s\n", show(c));
+  //a += b;
+  //printf("a: %s\n", show(a));
+  b[1] += 7;
+  b[3] = 6;
+  //printf("b: %s\n", show(b));
+  //if (a != c)
+  //  return 1;
+  //if (a == b)
+  //  return 2;
+  if (b[1] != 12)
+    return 3;
+  if (b[3] != 6)
+    return 4;
+  if (b.length != 4)
+    return 5;
 
   return 0;
 }

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -4,27 +4,28 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  vector(int) a = new_vector(int) [1, 2, 3];
-  printf("a: %s\n", show(a));
-  vector(int) b = new_vector(int) [4, 5, 6];
-  printf("b: %s\n", show(b));
-  vector(int) c = a + b;
-  printf("c: %s\n", show(c));
-  a += b;
-  printf("a: %s\n", show(a));
-  b[1] += 7;
-  b[3] = 6;
-  printf("b: %s\n", show(b));
-  if (a != c)
-    return 1;
-  if (a == b)
-    return 2;
-  if (b[1] != 12)
-    return 3;
-  if (b[3] != 6)
-    return 4;
-  if (b.length != 4)
-    return 5;
+  //init_vector(int) (2);
+  vector(int) a = new_vector(int) []; //[1, 2, 3];
+  /* printf("a: %s\n", show(a)); */
+  /* vector(int) b = new_vector(int) [4, 5, 6]; */
+  /* printf("b: %s\n", show(b)); */
+  /* vector(int) c = a + b; */
+  /* printf("c: %s\n", show(c)); */
+  /* a += b; */
+  /* printf("a: %s\n", show(a)); */
+  /* b[1] += 7; */
+  /* b[3] = 6; */
+  /* printf("b: %s\n", show(b)); */
+  /* if (a != c) */
+  /*   return 1; */
+  /* if (a == b) */
+  /*   return 2; */
+  /* if (b[1] != 12) */
+  /*   return 3; */
+  /* if (b[3] != 6) */
+  /*   return 4; */
+  /* if (b.length != 4) */
+  /*   return 5; */
 
   return 0;
 }

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -12,9 +12,9 @@ int main(int argc, char **argv) {
   //printf("a: %s\n", show(a));
   vector<int> b = vec<int> [4, 5, 6];
   //printf("b: %s\n", show(b));
-  //vector<int> c = a + b;
+  vector<int> c = a + b;
   //printf("c: %s\n", show(c));
-  //a += b;
+  a += b;
   //printf("a: %s\n", show(a));
   b[1] += 7;
   b[3] = 6;

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -19,10 +19,10 @@ int main(int argc, char **argv) {
   b[1] += 7;
   b[3] = 6;
   //printf("b: %s\n", show(b));
-  //if (a != c)
-  //  return 1;
-  //if (a == b)
-  //  return 2;
+  if (a != c)
+    return 1;
+  if (a == b)
+    return 2;
   if (b[1] != 12)
     return 3;
   if (b[3] != 6)

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -4,21 +4,23 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  vector<int> v = vec<int> [1, 2, 3];
-  vector<int> v1 = copy_vector(v);
-  printf("%d\n", v1[2]);
-
   vector<int> a = vec<int> [1, 2, 3];
-  //printf("a: %s\n", show(a));
+  printf("a: %s\n", show(a));
   vector<int> b = vec<int> [4, 5, 6];
-  //printf("b: %s\n", show(b));
+  printf("b: %s\n", show(b));
   vector<int> c = a + b;
-  //printf("c: %s\n", show(c));
+  printf("c: %s\n", show(c));
+  printf("a: %s\n", show(a));
   a += b;
-  //printf("a: %s\n", show(a));
+  printf("a: %s\n", show(a));
   b[1] += 7;
   b[3] = 6;
-  //printf("b: %s\n", show(b));
+  printf("b: %s\n", show(b));
+  vector<int> d = copy_vector(b);
+  b[2] = 7;
+  printf("b: %s\n", show(b));
+  printf("d: %s\n", show(d));
+  
   if (a != c)
     return 1;
   if (a == b)
@@ -29,6 +31,8 @@ int main(int argc, char **argv) {
     return 4;
   if (b.length != 4)
     return 5;
+  if (b == d)
+    return 6;
 
   return 0;
 }

--- a/extensions/vector/example1.xc
+++ b/extensions/vector/example1.xc
@@ -5,7 +5,10 @@
 
 int main(int argc, char **argv) {
   //init_vector(int) (2);
-  vector(int) a = new_vector(int) []; //[1, 2, 3];
+  vector(int) a = new_vector(int) [1, 2, 3];
+  printf("%d\n", a[2]);
+
+  /* vector(int) a = new_vector(int) [1, 2, 3]; */
   /* printf("a: %s\n", show(a)); */
   /* vector(int) b = new_vector(int) [4, 5, 6]; */
   /* printf("b: %s\n", show(b)); */

--- a/extensions/vector/example2-type-errors.xc
+++ b/extensions/vector/example2-type-errors.xc
@@ -4,11 +4,11 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  vector(int) a = new_vector(float) [1, 2, 3]; // TODO, fix this, no sub type checking
+  vector<int> a = vec<float> [1, 2, 3];
   printf("a: %s\n", show(a));
-  vector(int) b = new_vector(int) [4, 5, 6];
+  vector<int> b = new_vector<int> [4, 5, 6];
   printf("b: %s\n", show(b));
-  vector(int) c = a + b;
+  vector<int> c = a + b;
   printf("c: %s\n", show(c));
   a += b;
   printf("a: %s\n", show(a));

--- a/extensions/vector/example2-type-errors.xc
+++ b/extensions/vector/example2-type-errors.xc
@@ -6,7 +6,7 @@
 int main(int argc, char **argv) {
   vector<int> a = vec<float> [1, 2, 3];
   printf("a: %s\n", show(a));
-  vector<int> b = new_vector<int> [4, 5, 6];
+  vector<int> b = vec<int> [4, 5, 6];
   printf("b: %s\n", show(b));
   vector<int> c = a + b;
   printf("c: %s\n", show(c));

--- a/extensions/vector/example3-include-error.xc
+++ b/extensions/vector/example3-include-error.xc
@@ -2,17 +2,23 @@
 #include <stdlib.h>
 
 int main(int argc, char **argv) {
-  vector(int) a = new_vector(int) [1, 2, 3];
+  vector<int> a = vec<int> [1, 2, 3];
   printf("a: %s\n", show(a));
-  vector(int) b = new_vector(int) [4, 5, 6];
+  vector<int> b = vec<int> [4, 5, 6];
   printf("b: %s\n", show(b));
-  vector(int) c = a + b;
+  vector<int> c = a + b;
   printf("c: %s\n", show(c));
+  printf("a: %s\n", show(a));
   a += b;
   printf("a: %s\n", show(a));
   b[1] += 7;
   b[3] = 6;
   printf("b: %s\n", show(b));
+  vector<int> d = copy_vector(b);
+  b[2] = 7;
+  printf("b: %s\n", show(b));
+  printf("d: %s\n", show(d));
+  
   if (a != c)
     return 1;
   if (a == b)
@@ -21,6 +27,10 @@ int main(int argc, char **argv) {
     return 3;
   if (b[3] != 6)
     return 4;
+  if (b.length != 4)
+    return 5;
+  if (b == d)
+    return 6;
 
   return 0;
 }

--- a/extensions/vector/example4-sieve.xc
+++ b/extensions/vector/example4-sieve.xc
@@ -1,0 +1,30 @@
+
+#include <vector.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+vector<int> sieve(int n) {
+  vector<int> ints = vec<int>(n);
+  for (int i = 0; i < n; i++)
+    ints[i] = i;
+
+  vector<int> results = vec<int>[];
+  int num_results = 0;
+  for (int i = 2; i < n; i++) {
+    if (ints[i] != -1) {
+      for (int j = i * 2; j < n; j += i) {
+        ints[j] = -1;
+      }
+      results[num_results++] = i;
+    }
+  }
+
+  return results;
+}
+
+int main(int argc, char **argv) {
+  printf("sieve(100) = %s\n", show(sieve(100)));
+
+  return 0;
+}

--- a/extensions/vector/example5-nested.xc
+++ b/extensions/vector/example5-nested.xc
@@ -1,0 +1,18 @@
+
+#include <vector.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  vector<vector<string>> elems = vec<vector<string>> [];
+  elems[0] = vec<string> ["abcd"];
+
+  for (int i = 1; i < 10; i++) {
+    elems[i] = vec<string> ["Hello", "World", str(i), show(elems[i - 1])];
+  }
+
+  printf("%s\n", show(elems));
+
+  return 0;
+}

--- a/extensions/vector/example5-nested.xc
+++ b/extensions/vector/example5-nested.xc
@@ -8,7 +8,7 @@ int main(int argc, char **argv) {
   vector<vector<string>> elems = vec<vector<string>> [];
   elems[0] = vec<string> ["abcd"];
 
-  for (int i = 1; i < 10; i++) {
+  for (int i = 1; i < 7; i++) {
     elems[i] = vec<string> ["Hello", "World", str(i), show(elems[i - 1])];
   }
 

--- a/extensions/vector/example6-local-typedef-error.xc
+++ b/extensions/vector/example6-local-typedef-error.xc
@@ -1,0 +1,15 @@
+
+#include <vector.xh>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+  typedef int foo;
+ 
+  vector<foo> v = vec<foo> [1, 2, 3];
+
+  printf("%s\n", show(v));
+
+  return 0;
+}

--- a/extensions/vector/impl.xc
+++ b/extensions/vector/impl.xc
@@ -1,0 +1,82 @@
+// This file contains the functions that would optimally be templated.  Instead for now, we are just compiling this manually to get the ast
+
+#include <vector.xh>
+
+typedef int ty;
+
+typedef struct __attribute__((refId("edu:umn:cs:melt:exts:ableC:vector:_vector_s"))) _vector_s {
+  struct _vector_info _info;
+  ty *_contents;
+}* _vector;
+
+// Allocate a pointer to a generic vector and clear its fields
+static _vector _alloc_vector() {
+  _vector result = GC_malloc(sizeof(struct _vector_s));
+  return result;
+}
+
+// Access the value in a vector at an index
+static ty _index_vector(_vector v, size_t i) {
+  _check_index_vector(v->_info, v->_contents, i);
+  return v->_contents[i];
+}
+
+// Update the value in a vector at an index
+static ty _update_index_vector(_vector v, int i, ty val) {
+  _maybe_grow_vector_by_one(&v->_info, (void**)&v->_contents, i);
+  v->_contents[i] = val; // Use overloaded assign operator
+  return val;
+}
+
+// Copy one vector into another
+static _vector _copy_vector(_vector v) {
+  _vector result = _alloc_vector();
+  _init_vector(&result->_info, (void**)&result->_contents, v->_info.elem_size, v->_info.length);
+  for (size_t i = 0; i < v->_info.length; i++) {
+    _update_index_vector(v, i, _index_vector(v, i)); // Use vector abstract syntax
+  }
+  return result;
+}
+
+// Append a vector to another, updating the first
+static _vector _append_update_vector(_vector v1, _vector v2) {
+  _resize_vector(&v1->_info, (void**)&v1->_contents, v1->_info.length + v2->_info.length);
+  for (size_t i = 0; i < v2->_info.length; i++) {
+    _update_index_vector(v1, v1->_info.length + i, _index_vector(v2, i)); // Use vector abstract syntax
+  }
+  return v1;
+}
+
+// Append two vectors to create a new vector
+static _vector _append_vectors(_vector v1, _vector v2) {
+  _vector result = _copy_vector(v1);
+  return _append_update_vector(result, v2);
+}
+
+// Append a single item to a vector
+static void _append_item(_vector v, ty elem) {
+  _update_index_vector(v, v->_info.length, elem);
+}
+
+// Return true if two vectors are equal
+static bool _equal_vectors(_vector v1, _vector v2) {
+  if (v1->_info.length != v2->_info.length)
+    return false;
+  for (unsigned i = 0; i < v1->_info.length; i++) {
+    if (_index_vector(v1, i) != _index_vector(v2, i))
+      return false;
+  }
+  return true;
+}
+
+// Convert a vector to a string
+static string _showVector(_vector v) {
+  if (v->_info.length == 0)
+    return "[]";
+  string result = "[" + str(_index_vector(v, 0));
+  for (unsigned i = 1; i < v->_info.length; i++) {
+    result += ", " + str(_index_vector(v, i));
+  }
+  result += "]";
+  return result;
+}

--- a/extensions/vector/include/vector.xh
+++ b/extensions/vector/include/vector.xh
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include <stdbool.h>
+//#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -11,113 +12,48 @@
 #ifndef _VECTOR_XH
 #define _VECTOR_XH
 
-struct __attribute__((refId("edu:umn:cs:melt:exts:ableC:vector:_vector_s"))) _vector_s {
-  int length;
-  int capacity;
-  void **contents;
+struct _vector_info {
+  size_t length;
+  size_t capacity;
+  size_t elem_size;
 };
 
-typedef struct _vector_s *_vector;
-
-typedef string (*_ToStringFun)(void*);
-typedef bool (*_EqFun)(void*, void*);
-
-static void _check_index_vector(_vector v, int i) {
-  if (i >= v->length || i < 0) {
-    fprintf(stderr, "Vector index out of bounds: length %d, index %d\n", v->length, i);
+// Check whether an index is valid for given vector info
+static void _check_index_vector(struct _vector_info info, void *contents, size_t i) {
+  if (i >= info.length || i < 0) {
+    fprintf(stderr, "Vector index out of bounds: length %lud, index %lud\n", info.length, i);
+    exit(1);
+  }
+  if (contents == NULL) {
+    fprintf(stderr, "Cannot access uninitialized vector\n");
     exit(1);
   }
 }
 
-static void *_index_vector(_vector v, int i) {
-  _check_index_vector(v, i);
-  return v->contents[i];
-}
-
-static void _expand_vector(_vector v, int new_size) {
-  if (new_size > v->capacity) {
-    v->capacity = new_size;
-    v->contents = GC_realloc(v->contents, sizeof(void*) * new_size);
+// Increase the length of a vector to new_size, updating the given info and contents pointers
+static void _resize_vector(struct _vector_info *info, void **contents, size_t new_length) {
+  info->length = new_length;
+  if (new_length > info->capacity) {
+    info->capacity = new_length * 2;
+    *contents = GC_realloc(*contents, info->elem_size * info->capacity);
   }
 }
 
-static void *_update_index_vector(_vector v, int i, void *val, size_t elem_size) {
-  if (i > v->length || i < 0) {
-    fprintf(stderr, "Vector index out of bounds: length %d, index %d\n", v->length, i);
+// If the index is equal to the vector size, expand the vector by one
+static void _maybe_grow_vector_by_one(struct _vector_info *info, void **contents, size_t i) {
+  if (i > info->length || i < 0) {
+    fprintf(stderr, "Vector index out of bounds: length %lud, index %lud\n", info->length, i);
     exit(1);
   }
-  if (i == v->length) {
-    v->length++;
-    if (v->length == v->capacity)
-      _expand_vector(v, v->length * 2);
+  if (i == info->length) {
+    _resize_vector(info, contents, info->length + 1);
   }
-  v->contents[i] = GC_malloc(elem_size);
-  memcpy(v->contents[i], val, elem_size);
-  return v->contents[i];
 }
 
-static _vector _new_vector(int length, ...) {
-  _vector result = GC_malloc(sizeof(struct _vector_s));
-  result->length = length;
-  result->capacity = length;
-  result->contents = GC_malloc(sizeof(void*) * length);
-  
-  va_list ap;
-  va_start(ap, length);
-  for (int i = 0; i < length; i++) {
-    void *item = va_arg(ap, void*);
-    size_t size = va_arg(ap, size_t);
-    _update_index_vector(result, i, item, size);
-  }
-  va_end(ap);
-  
-  return result;
-}
-
-static _vector _copy_vector(_vector v) {
-  _vector result = GC_malloc(sizeof(struct _vector_s));
-  result->length = v->length;
-  result->capacity = v->length;
-  result->contents = GC_malloc(sizeof(void*) * v->length);
-  memcpy(result->contents, v->contents, sizeof(void*) * v->length);
-  return result;
-}
-
-static _vector _append_update_vector(_vector v1, _vector v2) {
-  _expand_vector(v1, v1->length + v2->length);
-  memcpy(&(v1->contents[v1->length]), v2->contents, sizeof(void*) * v2->length);
-  v1->length = v1->length + v2->length;
-  return v1;
-}
-
-static _vector _append_vectors(_vector v1, _vector v2) {
-  _vector result = _copy_vector(v1);
-  return _append_update_vector(result, v2);
-}
-
-static void _append_item(_vector v, void *elem, size_t elem_size) {
-  _update_index_vector(v, v->length, elem, elem_size);
-}
-
-static bool _equal_vectors(_vector v1, _vector v2, _EqFun eq) {
-  if (v1->length != v2->length)
-    return false;
-  for (int i = 0; i < v1->length; i++) {
-    if (!eq(v1->contents[i], v2->contents[i]))
-      return false;
-  }
-  return true;
-}
-
-static string _showVector(_vector v, _ToStringFun to_string) {
-  if (v->length == 0)
-    return "[]";
-  string result = "[" + to_string(v->contents[0]);
-  for (int i = 1; i < v->length; i++) {
-    result += ", " + to_string(v->contents[i]);
-  }
-  result += "]";
-  return result;
+// Initialize a vector to have a given size
+static void _init_vector(struct _vector_info *info, void **contents, size_t elem_size, size_t length) {
+  *info = (struct _vector_info){length, length * 2, elem_size};
+  *contents = GC_malloc(elem_size * info->capacity);
 }
 
 #endif

--- a/extensions/vector/include/vector.xh
+++ b/extensions/vector/include/vector.xh
@@ -21,7 +21,7 @@ struct _vector_info {
 // Check whether an index is valid for given vector info
 static void _check_index_vector(struct _vector_info info, void *contents, size_t i) {
   if (i >= info.length || i < 0) {
-    fprintf(stderr, "Vector index out of bounds: length %lud, index %lud\n", info.length, i);
+    fprintf(stderr, "Vector index out of bounds: length %lu, index %lu\n", info.length, i);
     exit(1);
   }
   if (contents == NULL) {
@@ -42,7 +42,7 @@ static void _resize_vector(struct _vector_info *info, void **contents, size_t ne
 // If the index is equal to the vector size, expand the vector by one
 static void _maybe_grow_vector_by_one(struct _vector_info *info, void **contents, size_t i) {
   if (i > info->length || i < 0) {
-    fprintf(stderr, "Vector index out of bounds: length %lud, index %lud\n", info->length, i);
+    fprintf(stderr, "Vector index out of bounds: length %lu, index %lu\n", info->length, i);
     exit(1);
   }
   if (i == info->length) {

--- a/testing/build/init_build.sh
+++ b/testing/build/init_build.sh
@@ -27,7 +27,7 @@ done
 # Other variables
 export ABLEC_SOURCE="$ABLEC_PATH/edu.umn.cs.melt.ableC/**/* artifact/Main.sv"
 export SILVER_INCLUDES="-I . -I $ABLEC_PATH"
-export JAVA_FLAGS="-Xss20M -Xms40m -Xmx2000M"
+export JAVA_FLAGS= #"-Xss20M -Xms40m -Xmx2000M"
 export CPPFLAGS=
 export TRANSLATE_DEPENDS=
 export CFLAGS="-g -std=gnu1x"


### PR DESCRIPTION
I revised the vector extension to make use of the current lifting mechanism.  Productions that could benefit from templating to define generic functions in a header file are commented as such, with the ASTs currently written manually in local attributes.  I also made a few bug fixes to the string extension.  

This required a few changes to the host:
* Added global decl injection productions for Stmt, BaseTypeExpr, and Type
* Added globalDeclsEnv attribute to Decls to track what globalDecls were inserted by a previous consGlobalDecls production to avoid duplicates
* Added env check to remove globalDecls from being defined that are already in the env
* Added an attribute on types to perform name mangling
* Added '>' to the follow set of TypeName_c to fix MDA errors
* Implemented type checking on memberExpr