### PR TITLE
Fix handling of directTypeExpr to make use of lifting

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -75,6 +75,7 @@ top::Decl ::= storage::[StorageClass]  attrs::[Attribute]  ty::BaseTypeExpr  dcl
   top.freeVariables = ty.freeVariables ++ dcls.freeVariables;
   
   dcls.baseType = ty.typerep;
+  dcls.typeModifiersIn = ty.typeModifiers;
   dcls.isTypedef = false;
   dcls.givenAttributes = attrs;
 }
@@ -101,6 +102,7 @@ top::Decl ::= attrs::[Attribute]  ty::BaseTypeExpr  dcls::Declarators
   top.freeVariables = ty.freeVariables ++ dcls.freeVariables;
   
   dcls.baseType = ty.typerep;
+  dcls.typeModifiersIn = ty.typeModifiers;
   dcls.isTypedef = true;
   dcls.givenAttributes = attrs;
 }
@@ -165,7 +167,7 @@ top::Decl ::= s::String
   -- but used to be the way to put c functions and such in custom sections.
 }
 
-nonterminal Declarators with pps, host<Declarators>, lifted<Declarators>, errors, globalDecls, defs, env, baseType, isTopLevel, isTypedef, givenAttributes, returnType, freeVariables;
+nonterminal Declarators with pps, host<Declarators>, lifted<Declarators>, errors, globalDecls, defs, env, baseType, typeModifiersIn, isTopLevel, isTypedef, givenAttributes, returnType, freeVariables;
 
 abstract production consDeclarator
 top::Declarators ::= h::Declarator  t::Declarators
@@ -192,7 +194,7 @@ top::Declarators ::=
   top.freeVariables = [];
 }
 
-nonterminal Declarator with pps, host<Declarator>, lifted<Declarator>, errors, globalDecls, defs, env, baseType, typerep, sourceLocation, isTopLevel, isTypedef, givenAttributes, returnType, freeVariables;
+nonterminal Declarator with pps, host<Declarator>, lifted<Declarator>, errors, globalDecls, defs, env, baseType, typeModifiersIn, typerep, sourceLocation, isTopLevel, isTypedef, givenAttributes, returnType, freeVariables;
 
 autocopy attribute isTypedef :: Boolean;
 
@@ -286,6 +288,7 @@ top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty:
   top.sourceLocation = name.location;
   
   mty.baseType = bty.typerep;
+  mty.typeModifiersIn = bty.typeModifiers;
   
   body.returnType =
     case mty of
@@ -405,6 +408,7 @@ top::ParameterDecl ::= storage::[StorageClass]  bty::BaseTypeExpr  mty::TypeModi
   top.freeVariables = bty.freeVariables ++ mty.freeVariables;
   
   mty.baseType = bty.typerep;
+  mty.typeModifiersIn = bty.typeModifiers;
   
   top.errors <- name.valueRedeclarationCheckNoCompatible;
 }
@@ -638,6 +642,7 @@ top::StructItem ::= attrs::[Attribute]  ty::BaseTypeExpr  dcls::StructDeclarator
   top.localdefs = dcls.localdefs;
   
   dcls.baseType = ty.typerep;
+  dcls.typeModifiersIn = ty.typeModifiers;
   dcls.givenAttributes = attrs;
 }
 abstract production warnStructItem
@@ -653,7 +658,7 @@ top::StructItem ::= msg::[Message]
 }
 
 
-nonterminal StructDeclarators with pps, host<StructDeclarators>, lifted<StructDeclarators>, errors, globalDecls, localdefs, env, baseType, givenAttributes, returnType, freeVariables;
+nonterminal StructDeclarators with pps, host<StructDeclarators>, lifted<StructDeclarators>, errors, globalDecls, localdefs, env, baseType, typeModifiersIn, givenAttributes, returnType, freeVariables;
 
 abstract production consStructDeclarator
 top::StructDeclarators ::= h::StructDeclarator  t::StructDeclarators
@@ -680,7 +685,7 @@ top::StructDeclarators ::=
   top.freeVariables = [];
 }
 
-nonterminal StructDeclarator with pps, host<StructDeclarator>, lifted<StructDeclarator>, errors, globalDecls, localdefs, env, typerep, sourceLocation, baseType, givenAttributes, returnType, freeVariables;
+nonterminal StructDeclarator with pps, host<StructDeclarator>, lifted<StructDeclarator>, errors, globalDecls, localdefs, env, typerep, sourceLocation, baseType, typeModifiersIn, givenAttributes, returnType, freeVariables;
 
 abstract production structField
 top::StructDeclarator ::= name::Name  ty::TypeModifierExpr  attrs::[Attribute]

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -5,7 +5,7 @@
 -- Declaration is rooted in External, but also in stmts. Either a variableDecl or a typedefDecl.
 -- ParameterDecl should probably be something special, distinct from variableDecl.
 
-nonterminal GlobalDecls with pps, host<GlobalDecls>, lifted<GlobalDecls>, errors, globalDecls, defs, globalDeclEnv, env, returnType, freeVariables;
+nonterminal GlobalDecls with pps, host<GlobalDecls>, lifted<GlobalDecls>, errors, defs, globalDeclEnv, env, returnType, freeVariables;
 
 {-- Mirrors Decls, used for lifting mechanism to insert new Decls at top level -}
 abstract production consGlobalDecl
@@ -18,7 +18,7 @@ top::GlobalDecls ::= h::Decl  t::GlobalDecls
     h.freeVariables ++
     removeDefsFromNames(h.defs, t.freeVariables);
   
-  -- host, lifted, globalDecls, globalDeclEnv defined in Lifted.sv
+  -- host, lifted, globalDeclEnv defined in Lifted.sv
     
   h.isTopLevel = true;
 }
@@ -29,7 +29,6 @@ top::GlobalDecls ::=
   propagate host, lifted;
   top.pps = [];
   top.errors := [];
-  top.globalDecls := [];
   top.defs = [];
   top.freeVariables = [];
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Host.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Host.sv
@@ -1,3 +1,9 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
+{--
+ - Functor attribute to compute the host AST corresponding to an extended AST
+ - Invariant:
+ - All non-forwarding (host) productions should functor-propagate host
+ - All forwarding (extension) productions should leave it undefined
+ -}
 synthesized attribute host<a>::a;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -13,10 +13,6 @@ A pair of synthesized attributes can be used for this.
 - `lifted`: the lifted tree.
 An invariant here is that all Decl nodes in the `host` tree appear in
 either `globalDecls` or in `lifted`.
-- On `Decls` nonterminals at the global level, `globalDecls` is empty
-  and all the `Decl` trees to be lifted (were in `globalDecls`) are now
-  put into `lifted`.
-- On all other nonterminals, `globalDecls` need not be empty.
 
 Another invariant is that declarations in globalDecls with the same name
 refer to an identical declaration, so that any duplicates can be safely
@@ -190,15 +186,12 @@ top::GlobalDecls ::= h::Decl  t::GlobalDecls
     removeDuplicateGlobalDeclPairs(h.globalDecls, top.globalDeclEnv);
   local newDecls::Decls = foldDecl(map(snd, newGlobalDeclPairs));
 
-  top.globalDecls := [];
   top.lifted =
-    if !null(t.globalDecls)
-    then error("consGlobalDecl tail has global decls!")
-    else consGlobalDecl( 
-           decls(newDecls),
-           consGlobalDecl(
-             h.lifted,
-             t.lifted));
+    consGlobalDecl( 
+      decls(newDecls),
+      consGlobalDecl(
+        h.lifted,
+        t.lifted));
   
   t.globalDeclEnv = top.globalDeclEnv ++ map(fst, newGlobalDeclPairs);
   t.env = addEnv(h.defs, top.env);

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -54,7 +54,6 @@ top::Expr ::= globalDecls::[Pair<String Decl>] lifted::Expr
   local decls::Decls = foldDecl(map(snd, newGlobalDecls));
   local names::[String] = map(fst, newGlobalDecls);
 
-  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = top.returnType;
@@ -95,7 +94,6 @@ top::Stmt ::= globalDecls::[Pair<String Decl>] lifted::Stmt
   local decls::Decls = foldDecl(map(snd, newGlobalDecls));
   local names::[String] = map(fst, newGlobalDecls);
 
-  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = top.returnType;
@@ -137,7 +135,6 @@ top::BaseTypeExpr ::= globalDecls::[Pair<String Decl>] lifted::BaseTypeExpr
   local decls::Decls = foldDecl(map(snd, newGlobalDecls));
   local names::[String] = map(fst, newGlobalDecls);
 
-  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = top.returnType;
@@ -181,11 +178,11 @@ top::NoncanonicalType ::= globalDecls::[Pair<String Decl>] lifted::Type
   top.typeModifierExpr = lifted.typeModifierExpr;
 }
 
--- Inserted globalDecls before h. Should only ever get used by top-level 
--- foldGlobalDecl in concrete syntax.
--- TODO: This should really be a seperate nonterminal from Decls
-abstract production consGlobalDecl
-top::Decls ::= h::Decl  t::Decls
+{--
+ - Inserts globalDecls before h
+ -}
+aspect production consGlobalDecl
+top::GlobalDecls ::= h::Decl  t::GlobalDecls
 {
   propagate host;
  
@@ -197,17 +194,14 @@ top::Decls ::= h::Decl  t::Decls
   top.lifted =
     if !null(t.globalDecls)
     then error("consGlobalDecl tail has global decls!")
-    else consDecl( 
+    else consGlobalDecl( 
            decls(newDecls),
-           consDecl(
+           consGlobalDecl(
              h.lifted,
              t.lifted));
   
   t.globalDeclEnv = top.globalDeclEnv ++ map(fst, newGlobalDeclPairs);
   t.env = addEnv(h.defs, top.env);
-  
-  -- define pp, env, defs, etc.
-  forwards to consDecl(h, t);
 }
 
 -- Removes duplicate global decls before inserting them

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -1,7 +1,7 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
 {- 
-Expressions that want to specify declartions to lift to a global scope
+Extensions that want to specify declartions to lift to a global scope
 do so by forwarding to the host production `injectGlobalDecls` (or one
 of the corresponding ones for Type or BaseTypeExpr.)  
 
@@ -12,7 +12,8 @@ A pair of synthesized attributes can be used for this.
 - `globalDecls`: the list of declarations to lift up
 - `lifted`: the lifted tree.
 An invariant here is that all Decl nodes in the `host` tree appear in
-either `globalDecls` or in `lifted`.
+either `globalDecls` or in `lifted`.  Also, the 'injection' productions
+defined here should not occur in the lifted tree.  
 
 Another invariant is that declarations in globalDecls with the same name
 refer to an identical declaration, so that any duplicates can be safely

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -123,6 +123,7 @@ top::BaseTypeExpr ::= globalDecls::[Pair<String Decl>] lifted::BaseTypeExpr
 {
   top.pp = pp"injectGlobalDeclsTypeExpr {${ppImplode(pp"\n", decls.pps)}} (${lifted.pp})";
   top.host = injectGlobalDeclsTypeExpr(zipWith(pair, names, unfoldDecl(decls.host)), lifted.host);
+  top.typerep = noncanonicalType(injectGlobalDeclsType(globalDecls, lifted.typerep));
   
   -- Remove the globalDecls that are already in the env (i.e. this is already part of a lifted ast)
   local newGlobalDecls::[Pair<String Decl>] = removeEnvGlobalDeclPairs(globalDecls, top.env);
@@ -157,83 +158,18 @@ top::BaseTypeExpr ::= globalDecls::[Pair<String Decl>] lifted::BaseTypeExpr
 
 {--
  - Lifting mechanism for types
- - Note that the invariant must be changed here, since we don't have access to an environment.  
- - This means that we can't define host to simply reproduce injectGlobalDeclsType with the host
- - version of globalDecls, since we have no way of decorating the decls here.  
- - Instead, we do away with lifted on types and simply have the host transformation replace all
- - instances of injectGlobalDeclsType with liftedType, and then the production that is performing
- - the host transformation must decorate the globalDecls and transform to a lifting production
- - 
+ - Since we don't have access to the environment, and Type doesn't occur in the host tree, this just gets
+ - turned into injectGlobalDeclsTypeExpr in the host tree
  -}
 abstract production injectGlobalDeclsType
 top::NoncanonicalType ::= globalDecls::[Pair<String Decl>] lifted::Type
 {
+  propagate host;
   top.canonicalType = lifted;
   top.lpp = pp"injectGlobalDeclsType {<not shown>} (${lifted.lpp})";
   top.rpp = lifted.rpp;
-   
-  top.host = liftedType(lifted.host);
-  top.globalDecls := globalDecls ++ lifted.globalDecls;
-}
-
--- A noncanonical type that is really just a normal type, after the lifting transformation has happened
-abstract production liftedType
-top::NoncanonicalType ::= lifted::Type
-{
-  propagate host;
-  top.canonicalType = lifted;
-  top.lpp = lifted.lpp;
-  top.rpp = lifted.rpp;
-  top.globalDecls := lifted.globalDecls;
-}
-
-{--
- - directTypeExpr now functions similarly to injectGlobalDecls, except that the decls to be lifted
- - are provided only via result.globalDecls
- - Also, the host transformation must lift globalDecls to thist point, so that they can be
- - decorated and host-transformed.  This means that the host Type tree shouldn't actually contain
- - any unlifted decls, so the lifted and globalDecls equations aren't strictly needed assuming that
- - lifted is only accessed after a host transformation, but they are included anyway for the sake
- - of completness.
- -}  
-aspect production directTypeExpr
-top::BaseTypeExpr ::= result::Type
-{
-  top.host = 
-    if !null(newGlobalDecls)
-    then
-      injectGlobalDeclsTypeExpr(
-        zipWith(pair, names, unfoldDecl(decls.host)),
-        freshenDirectTypeExpr(result.host))
-    else freshenDirectTypeExpr(result.host);
-  top.lifted = freshenDirectTypeExpr(result.host);
-  
-  -- Remove the globalDecls that are already in the env (i.e. this is already part of a lifted ast)
-  local newGlobalDecls::[Pair<String Decl>] =
-    removeEnvGlobalDeclPairs(result.globalDecls, top.env);
- 
-  local decls::Decls = foldDecl(map(snd, newGlobalDecls));
-  local names::[String] = map(fst, newGlobalDecls);
-
-  decls.globalDeclEnv = error("Demanded globalDeclEnv by consDecl");
-  decls.env = globalEnv(top.env);
-  decls.isTopLevel = true;
-  decls.returnType = top.returnType;
-  
-  top.errors <- decls.errors;
-
-  -- Note that the invariant over `globalDecls` and `lifted` is maintained.
-  top.globalDecls :=
-    decls.globalDecls ++ 
-    zipWith(pair, names, unfoldDecl(decls.lifted));
-}
-
-{-- When applying a functor attribute, we need to update the refIds in any types in directTypeExprs
- - to point to the new refIds defined in the new tags -}
-abstract production freshenDirectTypeExpr
-top::BaseTypeExpr ::= result::Type
-{
-  forwards to directTypeExpr(freshenRefIds(top.env, result));
+  top.baseTypeExpr = injectGlobalDeclsTypeExpr(globalDecls, lifted.baseTypeExpr);
+  top.typeModifierExpr = lifted.typeModifierExpr;
 }
 
 -- Inserted globalDecls before h. Should only ever get used by top-level 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -74,9 +74,12 @@ top::Expr ::= globalDecls::[Pair<String Decl>] lifted::Expr
   -- Shouldn't be a problem unless there are name conflicts, doing this the right way would be less
   -- efficent. 
   lifted.env = addEnv(decls.defs, top.env);
- 
-  forwards to lifted
-  with {env = lifted.env;};
+  
+  -- Define other attributes to be the same as on lifted
+  top.errors := lifted.errors;
+  top.defs = lifted.defs;
+  top.freeVariables = lifted.freeVariables;
+  top.typerep = lifted.typerep;
 }
 
 -- Same as injectGlobalDecls, but on Stmt
@@ -112,9 +115,12 @@ top::Stmt ::= globalDecls::[Pair<String Decl>] lifted::Stmt
   -- Shouldn't be a problem unless there are name conflicts, doing this the right way would be less
   -- efficent. 
   lifted.env = addEnv(decls.defs, top.env);
- 
-  forwards to lifted
-  with {env = lifted.env;};
+  
+  -- Define other attributes to be the same as on lifted
+  top.errors := lifted.errors;
+  top.functiondefs = lifted.functiondefs;
+  top.defs = lifted.defs;
+  top.freeVariables = lifted.freeVariables;
 }
 
 -- Same as injectGlobalDecls, but on BaseTypeExpr
@@ -152,8 +158,11 @@ top::BaseTypeExpr ::= globalDecls::[Pair<String Decl>] lifted::BaseTypeExpr
   -- doing this the right way would be less efficent.  
   lifted.env = addEnv(decls.defs, top.env);
   
-  forwards to lifted
-  with {env = lifted.env;};
+  -- Define other attributes to be the same as on lifted
+  top.errors := lifted.errors;
+  top.typeModifiers = lifted.typeModifiers;
+  top.defs = lifted.defs;
+  top.freeVariables = lifted.freeVariables;
 }
 
 {--
@@ -174,6 +183,7 @@ top::NoncanonicalType ::= globalDecls::[Pair<String Decl>] lifted::Type
 
 -- Inserted globalDecls before h. Should only ever get used by top-level 
 -- foldGlobalDecl in concrete syntax.
+-- TODO: This should really be a seperate nonterminal from Decls
 abstract production consGlobalDecl
 top::Decls ::= h::Decl  t::Decls
 {

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Lifted.sv
@@ -1,34 +1,34 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
 {- 
-Extensions that want to specify declartions to lift to a global scope
-do so by forwarding to the host production `injectGlobalDecls` (or one
-of the corresponding ones for Type or BaseTypeExpr.)  
-
-After extracting the `host` tree, there are no extension constructs,
-but declarations need to be lifted to the proper place. 
-
-A pair of synthesized attributes can be used for this.
-- `globalDecls`: the list of declarations to lift up
-- `lifted`: the lifted tree.
-An invariant here is that all Decl nodes in the `host` tree appear in
-either `globalDecls` or in `lifted`.  Also, the 'injection' productions
-defined here should not occur in the lifted tree.  
-
-Another invariant is that declarations in globalDecls with the same name
-refer to an identical declaration, so that any duplicates can be safely
-removed.  This is left up to the extension writer for now, but there may
-a better solution.  
-
-TODO:
-Right now we assume the name in any globalDecls pairs corresponds to a
-ValueItem that is being defined.  We should find a way to generalize this,
-possibly leveraging some of the current env stuff, to allow things like
-non-typedef'ed structs to be lifted.  
-
-It would be nice to move all of this to its own grammar, but aspecting
-everything for lifted and globalDecls would be kind of a pain
--}
+ - Extensions that want to specify declartions to lift to a global scope
+ - do so by forwarding to the host production `injectGlobalDecls` (or one
+ - of the corresponding ones for Type or BaseTypeExpr.)  
+ - 
+ - After extracting the `host` tree, there are no extension constructs,
+ - but declarations need to be lifted to the proper place. 
+ - 
+ - A pair of synthesized attributes can be used for this.
+ - * `globalDecls`: the list of declarations to lift up
+ - * `lifted`: the lifted tree.
+ - An invariant here is that all Decl nodes in the `host` tree appear in
+ - either `globalDecls` or in `lifted`.  Also, the 'injection' productions
+ - defined here should not occur in the lifted tree.  
+ - 
+ - Another invariant is that declarations in globalDecls with the same name
+ - refer to an identical declaration, so that any duplicates can be safely
+ - removed.  This is left up to the extension writer for now, but there may
+ - a better solution.  
+ - 
+ - TODO:
+ - Right now we assume the name in any globalDecls pairs corresponds to a
+ - ValueItem that is being defined.  We should find a way to generalize this,
+ - possibly leveraging some of the current env stuff, to allow things like
+ - non-typedef'ed structs to be lifted.  
+ - 
+ - It would be nice to move all of this to its own grammar, but aspecting
+ - everything for lifted and globalDecls would be kind of a pain
+ -}
 
 synthesized attribute lifted<a>::a;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
@@ -8,7 +8,7 @@ global fullErrorCheck::Boolean = true;
 nonterminal Root with pp, host<Root>, lifted<Root>, errors, globalDecls, env;
 
 abstract production root
-top::Root ::= d::Decls
+top::Root ::= d::GlobalDecls
 {
   propagate host, lifted;
   
@@ -19,7 +19,6 @@ top::Root ::= d::Decls
   d.globalDeclEnv = [];
 --  d.env = addEnv(builtinfunctions:initialEnv;
   d.env = addEnv(builtinfunctions:getInitialEnvDefs(), top.env);
-  d.isTopLevel = true;
   d.returnType = nothing();
 }
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Root.sv
@@ -5,7 +5,7 @@ import edu:umn:cs:melt:ableC:abstractsyntax:builtins as builtinfunctions;
 
 global fullErrorCheck::Boolean = true;
 
-nonterminal Root with pp, host<Root>, lifted<Root>, errors, globalDecls, env;
+nonterminal Root with pp, host<Root>, lifted<Root>, errors, env;
 
 abstract production root
 top::Root ::= d::GlobalDecls
@@ -14,7 +14,6 @@ top::Root ::= d::GlobalDecls
   
   top.pp = terminate(line(), d.pps);
   top.errors := d.errors;
-  top.globalDecls := d.globalDecls;
   
   d.globalDeclEnv = [];
 --  d.env = addEnv(builtinfunctions:initialEnv;
@@ -49,9 +48,6 @@ top::Compilation ::= srcAst::Root
     then wrn(loc("", -1, -1, -1, -1, -1, -1), "Errors in host tree:") :: hostAst.errors
     else if !null(liftedAst.errors)
     then wrn(loc("", -1, -1, -1, -1, -1, -1), "Errors in lifted tree:") :: liftedAst.errors
-    else if !null(liftedAst.globalDecls)
-    then [wrn(loc("Top level", -1, -1, -1, -1, -1, -1),
-              "globalDecls at top level in lifted tree: " ++ implode(", ", map(fst, liftedAst.globalDecls)))]
     else [];
   
   top.srcAst = srcAst;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Stmt.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Stmt.sv
@@ -74,6 +74,7 @@ top::Stmt ::= d::Decl
 }
 
 -- Most common use case, makes things easier for extensions
+-- TODO: Remove this, duplicate of DeclHelpers.sv
 abstract production basicVarDeclStmt
 top::Stmt ::= t::Type n::Name init::Expr
 {

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -107,6 +107,7 @@ top::BaseTypeExpr ::= result::Type
 
 {-- A TypeExpr that contains a type modifer which must be lifted out
  - This production should not occur in the host AST
+ - TODO: Should this transformation happen with host or lifted?
  -}
 abstract production typeModiferTypeExpr
 top::BaseTypeExpr ::= bty::BaseTypeExpr  mty::TypeModifierExpr
@@ -339,7 +340,12 @@ top::BaseTypeExpr ::= q::[Qualifier]  e::ExprOrTypeName
  -}
 nonterminal TypeModifierExpr with env, typerep, lpp, rpp, host<TypeModifierExpr>, lifted<TypeModifierExpr>, baseType, typeModifiersIn, errors, globalDecls, returnType, freeVariables;
 
-
+{--
+ - A TypeModifierExpr that corresponds to whatever the base TypeExpr was.  
+ - This gets transformed to include type modifiers that were included in the base TypeExpr
+ - via typeModifierTypeExpr.  
+ - TODO: Should this transformation happen with host or lifted?
+ -}
 abstract production baseTypeExpr
 top::TypeModifierExpr ::=
 {

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -1,27 +1,31 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
--- In order to accomodate C's odd-ball syntax when it comes to type declarations
--- (with specifiers separate from declarators) we have a divided Type Expressions
--- abstract syntax.
-
--- BaseTypeExpr represents specifiers: structs, typedefs, ints, etc
--- TypeModifierExpr represents declarators: pointers, arrays, functions, etc.
-
--- We can't merge these into one TypeExpr because a BaseTypeExpr might be
--- used as part of several declarators.
--- For example, "struct { ... } bar, *baz;"
--- Here, we declare two variables: bar and baz. one of the anonymous struct
--- type, the other a pointer to it. However, we must NOT duplicate the
--- declaration of the struct!
--- That is, we cannot represent it as "struct { ... } bar; struct { ... } *baz;"
--- because that redeclares the type.
-
--- Our solution is to have a BaseTypeExprs for a declarations, followed by
--- several identifiers each with their own TypeModifiersExpr.
--- This way, the struct appears once in the abstract syntax.
-
--- TypeModifiersExpr are terminated by "baseTypeExpr" which provides a typerep
--- value that is equal to the Type obtained from the corresponding BaseTypeExpr.
+{-- In order to accomodate C's odd-ball syntax when it comes to type declarations
+ - (with specifiers separate from declarators) we have a divided Type Expressions
+ - abstract syntax.
+ -
+ - BaseTypeExpr represents specifiers: structs, typedefs, ints, etc
+ - TypeModifierExpr represents declarators: pointers, arrays, functions, etc.
+ -
+ - We can't merge these into one TypeExpr because a BaseTypeExpr might be
+ - used as part of several declarators.
+ - For example, "struct { ... } bar, *baz;"
+ - Here, we declare two variables: bar and baz. one of the anonymous struct
+ - type, the other a pointer to it. However, we must NOT duplicate the
+ - declaration of the struct!
+ - That is, we cannot represent it as "struct { ... } bar; struct { ... } *baz;"
+ - because that redeclares the type.
+ -
+ - Our solution is to have a BaseTypeExprs for a declarations, followed by
+ - several identifiers each with their own TypeModifiersExpr.
+ - This way, the struct appears once in the abstract syntax.
+ -
+ - TypeModifiersExpr are terminated by "baseTypeExpr" which provides a typerep
+ - value that is equal to the Type obtained from the corresponding BaseTypeExpr.
+ - 
+ - Invariant: a BaseTypeExpr and its corresponding TypeModifierExpr should have
+ - the same environment
+ -}
 
 autocopy attribute baseType :: Type;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -33,7 +33,7 @@ synthesized attribute rpp :: Document;
 synthesized attribute typerep :: Type;
 synthesized attribute typereps :: [Type];
 
-{-- Used to transform away typeModiferTypeExpr -}
+{-- Used to transform away typeModifierTypeExpr -}
 synthesized attribute typeModifiers :: [TypeModifierExpr];
 autocopy attribute typeModifiersIn :: [TypeModifierExpr];
 
@@ -101,14 +101,14 @@ top::BaseTypeExpr ::= result::Type
   forwards to
     case result.typeModifierExpr of
       baseTypeExpr() -> result.baseTypeExpr
-    | _ -> typeModiferTypeExpr(result.baseTypeExpr, result.typeModifierExpr)
+    | _ -> typeModifierTypeExpr(result.baseTypeExpr, result.typeModifierExpr)
     end;
 }
 
-{-- A TypeExpr that contains a type modifer which must be lifted out
+{-- A TypeExpr that contains a type modifier which must be lifted out
  - This production should not occur in the lifted AST
  -}
-abstract production typeModiferTypeExpr
+abstract production typeModifierTypeExpr
 top::BaseTypeExpr ::= bty::BaseTypeExpr  mty::TypeModifierExpr
 {
   propagate host;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -106,14 +106,13 @@ top::BaseTypeExpr ::= result::Type
 }
 
 {-- A TypeExpr that contains a type modifer which must be lifted out
- - This production should not occur in the host AST
- - TODO: Should this transformation happen with host or lifted?
+ - This production should not occur in the lifted AST
  -}
 abstract production typeModiferTypeExpr
 top::BaseTypeExpr ::= bty::BaseTypeExpr  mty::TypeModifierExpr
 {
+  propagate host;
   top.pp = parens(concat([bty.pp, mty.lpp, mty.rpp]));
-  top.host = bty.host;
   top.lifted = bty.lifted;
   top.typerep = mty.typerep;
   mty.baseType = bty.typerep;
@@ -342,16 +341,15 @@ nonterminal TypeModifierExpr with env, typerep, lpp, rpp, host<TypeModifierExpr>
 
 {--
  - A TypeModifierExpr that corresponds to whatever the base TypeExpr was.  
- - This gets transformed to include type modifiers that were included in the base TypeExpr
- - via typeModifierTypeExpr.  
- - TODO: Should this transformation happen with host or lifted?
+ - This gets transformed via lifted to include type modifiers that were included in the base
+ - TypeExpr via typeModifierTypeExpr.  
  -}
 abstract production baseTypeExpr
 top::TypeModifierExpr ::=
 {
+  propagate host;
   top.lpp = notext();
   top.rpp = notext();
-  top.host = if !null(top.typeModifiersIn) then mty.host else baseTypeExpr();
   top.lifted = if !null(top.typeModifiersIn) then mty.lifted else baseTypeExpr();
   
   local mty::TypeModifierExpr = head(top.typeModifiersIn);

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
@@ -319,32 +319,3 @@ Type ::= qs::[Qualifier] base::Type
   base.addedTypeQualifiers = qs;
   return base.withTypeQualifiers;
 }
-
-function freshenRefIds
-Type ::= newEnv::Decorated Env t::Type
-{
-  return case t of
-    tagType(q, refIdTagType(k, n, r)) ->
-      case lookupTag(n, newEnv) of
-        refIdTagItem(tag, refId) :: _ -> tagType(q, refIdTagType(k, n, refId))
-      | _ -> error(s"ref id for tag ${n} not found in new env") --${show(80, showEnv(newEnv))}
-      end
-  | tagType(q, enumTagType(d)) -> tagType(q, enumTagType(d))
-  | atomicType(q, t) -> atomicType(q, freshenRefIds(newEnv, t))
-  | pointerType(q, t)  -> pointerType(q, freshenRefIds(newEnv, t))
-  | arrayType(t, q, sm, sub) -> arrayType(freshenRefIds(newEnv, t), q, sm, sub)
-  | functionType(t, noProtoFunctionType()) ->
-    functionType(freshenRefIds(newEnv, t), noProtoFunctionType())
-  | functionType(t, protoFunctionType(ts, v)) ->
-    functionType(freshenRefIds(newEnv, t), protoFunctionType(map(freshenRefIds(newEnv, _), ts), v))
-  | vectorType(t, s) -> vectorType(freshenRefIds(newEnv, t), s)
-  | noncanonicalType(parenType(t)) -> noncanonicalType(parenType(freshenRefIds(newEnv, t)))
-  | noncanonicalType(decayedType(t1, t2)) ->
-    noncanonicalType(decayedType(freshenRefIds(newEnv, t1), freshenRefIds(newEnv, t2)))
-  | noncanonicalType(typedefType(q, n, t)) ->
-    noncanonicalType(typedefType(q, n, freshenRefIds(newEnv, t)))
-  | noncanonicalType(typeofType(q, t)) ->
-    noncanonicalType(typeofType(q, freshenRefIds(newEnv, t)))
-  | _ -> t
-  end;
-}

--- a/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
@@ -74,7 +74,7 @@ Parameters ::= l::[ParameterDecl]
 {
   return case l of
   -- A special case.  "type name(void)"  means no parameters.
-  | parameterDecl([], directTypeExpr(builtinType([], voidType())), baseTypeExpr(), nothingName(), []) :: [] -> nilParameters()
+  | parameterDecl([], builtinTypeExpr([], voidType()), baseTypeExpr(), nothingName(), []) :: [] -> nilParameters()
   | _ -> foldr(consParameters, nilParameters(), l)
   end;
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
@@ -28,9 +28,9 @@ function unfoldDecl
 }
 
 function foldGlobalDecl
-Decls ::= l::[Decl]
+GlobalDecls ::= l::[Decl]
 {
-  return foldr(consGlobalDecl, nilDecl(), l);
+  return foldr(consGlobalDecl, nilGlobalDecl(), l);
 }
 
 function foldInit

--- a/edu.umn.cs.melt.ableC/abstractsyntax/construction/Helpers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/construction/Helpers.sv
@@ -17,7 +17,7 @@ BaseTypeExpr ::= l::Location  q::[Qualifier]  pre_ts::[String]  real_ts::[BaseTy
     end
   else if null(pre_ts) && null(real_ts) then
     warnTypeExpr([wrn(l, "Implicit int type specifier -- illegal in C11")],
-      directTypeExpr(builtinType(q, signedType(intType()))))
+      builtinTypeExpr(q, signedType(intType())))
   else if !null(pre_ts) && !null(real_ts) then
     errorTypeExpr([err(l, "Multiple type specifiers" {- TODO -})])
   else if null(pre_ts) then
@@ -42,108 +42,108 @@ Maybe<BaseTypeExpr> ::= q::[Qualifier]  sorted_type_specifiers::[String]
   return case sorted_type_specifiers of
   -- signed char:
   | "char" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(charType()))))
+      just(builtinTypeExpr(q, signedType(charType())))
   | "char" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(charType()))))
+      just(builtinTypeExpr(q, signedType(charType())))
   -- unsigned char:
   | "char" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(charType()))))
+      just(builtinTypeExpr(q, unsignedType(charType())))
   -- signed short:
   | "short" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(shortType()))))
+      just(builtinTypeExpr(q, signedType(shortType())))
   | "short" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(shortType()))))
+      just(builtinTypeExpr(q, signedType(shortType())))
   | "int" :: "short" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(shortType()))))
+      just(builtinTypeExpr(q, signedType(shortType())))
   | "int" :: "short" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(shortType()))))
+      just(builtinTypeExpr(q, signedType(shortType())))
   -- unsigned short:
   | "int" :: "short" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(shortType()))))
+      just(builtinTypeExpr(q, unsignedType(shortType())))
   | "short" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(shortType()))))
+      just(builtinTypeExpr(q, unsignedType(shortType())))
   -- signed int:
   | "int" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(intType()))))
+      just(builtinTypeExpr(q, signedType(intType())))
   | "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(intType()))))
+      just(builtinTypeExpr(q, signedType(intType())))
   | "int" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(intType()))))
+      just(builtinTypeExpr(q, signedType(intType())))
   -- unsigned int:
   | "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(intType()))))
+      just(builtinTypeExpr(q, unsignedType(intType())))
   | "int" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(intType()))))
+      just(builtinTypeExpr(q, unsignedType(intType())))
   -- signed long:
   | "long" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longType()))))
+      just(builtinTypeExpr(q, signedType(longType())))
   | "long" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longType()))))
+      just(builtinTypeExpr(q, signedType(longType())))
   | "int" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longType()))))
+      just(builtinTypeExpr(q, signedType(longType())))
   | "int" :: "long" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longType()))))
+      just(builtinTypeExpr(q, signedType(longType())))
   -- unsigned long:
   | "int" :: "long" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(longType()))))
+      just(builtinTypeExpr(q, unsignedType(longType())))
   | "long" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(longType()))))
+      just(builtinTypeExpr(q, unsignedType(longType())))
   -- signed long long:
   | "long" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longlongType()))))
+      just(builtinTypeExpr(q, signedType(longlongType())))
   | "long" :: "long" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longlongType()))))
+      just(builtinTypeExpr(q, signedType(longlongType())))
   | "int" :: "long" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longlongType()))))
+      just(builtinTypeExpr(q, signedType(longlongType())))
   | "int" :: "long" :: "long" :: "signed" :: [] ->
-      just(directTypeExpr(builtinType(q, signedType(longlongType()))))
+      just(builtinTypeExpr(q, signedType(longlongType())))
   -- unsigned long:
   | "int" :: "long" :: "long" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(longlongType()))))
+      just(builtinTypeExpr(q, unsignedType(longlongType())))
   | "long" :: "long" :: "unsigned" :: [] ->
-      just(directTypeExpr(builtinType(q, unsignedType(longlongType()))))
+      just(builtinTypeExpr(q, unsignedType(longlongType())))
   -- float:
   | "float" :: [] ->
-      just(directTypeExpr(builtinType(q, realType(floatType()))))
+      just(builtinTypeExpr(q, realType(floatType())))
   -- double:
   | "double" :: [] ->
-      just(directTypeExpr(builtinType(q, realType(doubleType()))))
+      just(builtinTypeExpr(q, realType(doubleType())))
   -- long double:
   | "double" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, realType(longdoubleType()))))
+      just(builtinTypeExpr(q, realType(longdoubleType())))
   -- float _Complex:
   | "_Complex" :: "float" :: [] ->
-      just(directTypeExpr(builtinType(q, complexType(floatType()))))
+      just(builtinTypeExpr(q, complexType(floatType())))
   -- double _Complex:
   | "_Complex" :: "double" :: [] ->
-      just(directTypeExpr(builtinType(q, complexType(doubleType()))))
+      just(builtinTypeExpr(q, complexType(doubleType())))
   -- long double _Complex:
   | "_Complex" :: "double" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, complexType(longdoubleType()))))
+      just(builtinTypeExpr(q, complexType(longdoubleType())))
   -- float _Imaginary:
   | "_Imaginary" :: "float" :: [] ->
-      just(directTypeExpr(builtinType(q, imaginaryType(floatType()))))
+      just(builtinTypeExpr(q, imaginaryType(floatType())))
   -- double _Imaginary:
   | "_Imaginary" :: "double" :: [] ->
-      just(directTypeExpr(builtinType(q, imaginaryType(doubleType()))))
+      just(builtinTypeExpr(q, imaginaryType(doubleType())))
   -- long double _Imaginary:
   | "_Imaginary" :: "double" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, imaginaryType(longdoubleType()))))
+      just(builtinTypeExpr(q, imaginaryType(longdoubleType())))
   -- char _Complex:
   | "_Complex" :: "char" :: [] ->
-      just(directTypeExpr(builtinType(q, complexIntegerType(charType()))))
+      just(builtinTypeExpr(q, complexIntegerType(charType())))
   -- short _Complex:
   | "_Complex" :: "short" :: [] ->
-      just(directTypeExpr(builtinType(q, complexIntegerType(shortType()))))
+      just(builtinTypeExpr(q, complexIntegerType(shortType())))
   -- int _Complex:
   | "_Complex" :: "int" :: [] ->
-      just(directTypeExpr(builtinType(q, complexIntegerType(intType()))))
+      just(builtinTypeExpr(q, complexIntegerType(intType())))
   -- long _Complex:
   | "_Complex" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, complexIntegerType(longType()))))
+      just(builtinTypeExpr(q, complexIntegerType(longType())))
   -- long long _Complex:
   | "_Complex" :: "long" :: "long" :: [] ->
-      just(directTypeExpr(builtinType(q, complexIntegerType(longlongType()))))
+      just(builtinTypeExpr(q, complexIntegerType(longlongType())))
   
   | _ -> nothing()
   end;

--- a/edu.umn.cs.melt.ableC/concretesyntax/DeclSpecifiers.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/DeclSpecifiers.sv
@@ -196,7 +196,7 @@ concrete productions top::StorageClassSpecifier_c
 closed nonterminal TypeSpecifier_c with location, preTypeSpecifiers, realTypeSpecifiers, givenQualifiers; 
 concrete productions top::TypeSpecifier_c
 | 'void'
-    { top.realTypeSpecifiers = [ast:directTypeExpr(ast:builtinType(top.givenQualifiers, ast:voidType()))];
+    { top.realTypeSpecifiers = [ast:builtinTypeExpr(top.givenQualifiers, ast:voidType())];
       top.preTypeSpecifiers = []; }
 | 'char'
     { top.realTypeSpecifiers = [];
@@ -223,7 +223,7 @@ concrete productions top::TypeSpecifier_c
     { top.realTypeSpecifiers = [];
       top.preTypeSpecifiers = ["unsigned"]; }
 | '_Bool'
-    { top.realTypeSpecifiers = [ast:directTypeExpr(ast:builtinType(top.givenQualifiers, ast:boolType()))];
+    { top.realTypeSpecifiers = [ast:builtinTypeExpr(top.givenQualifiers, ast:boolType())];
       top.preTypeSpecifiers = []; }
 | '_Imaginary'
     { top.realTypeSpecifiers = [];

--- a/edu.umn.cs.melt.ableC/concretesyntax/Root.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/Root.sv
@@ -6,7 +6,7 @@ concrete productions top::Root
 | tu::TranslationUnit_c 
     { top.ast = ast:root(ast:foldGlobalDecl(tu.ast)); } -- Changed from foldDecl, this is used for handling extension global decls
 |
-    { top.ast = ast:root(ast:nilDecl()); }
+    { top.ast = ast:root(ast:nilGlobalDecl()); }
 
 
 closed nonterminal TranslationUnit_c with location, ast<[ast:Decl]>; 


### PR DESCRIPTION
This fixes issues #22 and #23.  

## TypeModiferExpr lifting
I added two new productions on BaseTypeExpr.  builtinTypeExpr takes a BuiltinType and wraps it as a BaseTypeExpr.  typeModifierTypeExpr takes a BaseTypeExpr and a TypeModifierExpr, wrapping them into a BaseTypeExpr.  This TypeModifierExpr must be moved to the bottom of the TypeModiferExpr tree corresponding to the BaseTypeExpr before code can be generated.  This is done via the lifted transformation.  

To do this, BaseTypeExpr has a new synthesized attribute `typeModifiers :: [TypeModiferExpr]`, and TypeModiferExpr a new inherited attribute `typeModifiersIn :: [TypeModiferExpr]`.  These collect all TypeModifierExprs in a BaseTypeExpr, in order of nesting, and send them back down the TypeModiferExpr tree to baseTypeExpr.  These attributes must be provided from BaseTypeExpr to TypeModifierExpr everywhere these are used (declarator, parameterDecl, etc.)  

The lifted attribute on typeModifierTypeExpr is then defined to just be the parameter BaseTypeExpr, and lifted on baseTypeExpr is defined to be the first TypeModifierExpr from typeModifiersIn, with its baseTypeExpr substituted for the next element of typeModifiersIn, etc.  This is computed by decorating the head of the list with typeModifiersIn as the tail of the list, then requesting lifted from that so that the process works recursively.  

## directTypeExpr translation
Types now have two new attributes, baseTypeExpr and typeModiferExpr, to compute the BaseTypeExpr and TypeModiferExpr for a Type.  This is fairly straightforward, except for the case of the gcc extension vectorType, since it required defining a BaseTypeExpr containing attributes.  We probably want to implement a production to do this, but that is something to fix at a later date.  

directTypeExpr can now forward to typeModifierTypeExpr with the type expressions that were created from the Type.  The pp and typerep are overridden to be the pp and parameter type, so that special types that extensions define are preserved in the original tree.  

This also nicely handles lifting on Type, since injectGlobalDeclsType can just turn into injectGlobalDeclsTypeExpr via this transformation.  Performing globalDecl lifting at the same time as the  transformation is not an issue, since the globalDecls and lifted both get accessed at the same time for BaseTypeExpr, and TypeModifierExpr gets redecorated with the same environment to access lifted once it gets transformed.  

## Lifting refactoring
I also did some refactoring of globalDecls lifting.  

I modified the injection productions to no longer forward to the lifted expression and instead define all attributes manually.  This removes a potential problem with interference.  

I also added a GlobalDecls nonterminal that mirrors Decls, but with a few slightly different attributes related to lifting.  This removes the forwarding dependency on globalDeclEnv, and also lets us get rid of a few equations that are `error("This shouldn't ever get accessed on Decls")` on the right-hand side.  