### PR TITLE
fix INTERNAL compiler error when using labelStmt

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/Name.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Name.sv
@@ -43,7 +43,7 @@ top::Name ::= n::String
   top.tagHasForwardDcl = refIdIfOld.isJust;
   top.tagRefId = fromMaybe(toString(genInt()), refIdIfOld);
   
-  local labdcls :: [LabelItem] = lookupLabelInLocalScope(n, top.env);
+  local labdcls :: [LabelItem] = lookupLabel(n, top.env);
   top.labelRedeclarationCheck =
     case labdcls of
     | [] -> [err(top.location, "INTERNAL compiler error: expected to find label in function scope, was missing.")] -- TODO?


### PR DESCRIPTION
When checking that a label has been declared precisely once in a function, lookup the label in any scope, not only the local scope.

Without this change, "INTERNAL compiler error: expected to find label in function scope, was missing" occurs when compiling the following:

```c
int main(void) {
l:
  return 0;
}
```