### PR TITLE
Workaround for Silver issue 139.

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/AsmConstruct.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/AsmConstruct.sv
@@ -5,7 +5,7 @@ abstract production asmStatement
 a::AsmStatement ::= arg::AsmArgument
 {
   propagate host, lifted;
-  a.pp = concat( [ text("asm ("), arg.pp, text(")"), text(";") ] );
+  a.pp = ppConcat( [ text("asm ("), arg.pp, text(")"), text(";") ] );
   a.freeVariables = arg.freeVariables;
 }
 
@@ -13,7 +13,7 @@ abstract production asmStatementTypeQual
 a::AsmStatement ::= tq::Qualifier arg::AsmArgument
 {
   propagate host, lifted;
-  a.pp = concat( [ text("asm "), tq.pp, text(" ("), arg.pp, text(")"), text(";") ] );
+  a.pp = ppConcat( [ text("asm "), tq.pp, text(" ("), arg.pp, text(")"), text(";") ] );
   a.freeVariables = arg.freeVariables;
 }
 
@@ -22,7 +22,7 @@ abstract production asmArgument
 top::AsmArgument ::= s::String asmOps1::AsmOperands asmOps2::AsmOperands asmC::AsmClobbers
 {
   propagate host, lifted;
-  top.pp = concat( [ text(s) ]
+  top.pp = ppConcat( [ text(s) ]
              ++ (if asmOps1Exists || asmOps2Exists || asmClobExists then [text(": ")] else [ ])  
              ++ [asmOps1.pp]
              ++ (if asmOps2Exists || asmClobExists then [text(": ")] else [ ])
@@ -57,7 +57,7 @@ abstract production snocAsmClobbers
 top::AsmClobbers ::= asmC::AsmClobbers s::String
 {
   propagate host, lifted;
-  top.pp = concat( [asmC.pp, text(", "), text(s) ] );
+  top.pp = ppConcat( [asmC.pp, text(", "), text(s) ] );
 }
 
 nonterminal AsmOperands with location, pp, host<AsmOperands>, lifted<AsmOperands>, env, returnType, freeVariables;
@@ -79,7 +79,7 @@ abstract production snocAsmOps
 top::AsmOperands ::= asmOps::AsmOperands asmOp::AsmOperand
 {
   propagate host, lifted;
-  top.pp = concat ( [asmOps.pp, text(", "), asmOp.pp] );
+  top.pp = ppConcat ( [asmOps.pp, text(", "), asmOp.pp] );
   top.freeVariables = asmOp.freeVariables ++ asmOps.freeVariables;
 }
 
@@ -88,7 +88,7 @@ abstract production asmOperand
 top::AsmOperand ::= s::String e::Expr
 { 
   propagate host, lifted;
-  top.pp = concat( [ text(s), text(" ("), e.pp, text(")") ] );
+  top.pp = ppConcat( [ text(s), text(" ("), e.pp, text(")") ] );
   top.freeVariables = e.freeVariables;
 }
 
@@ -96,6 +96,6 @@ abstract production asmOperandId
 top::AsmOperand ::= id::Name  s::String e::Expr
 {
   propagate host, lifted;
-  top.pp = concat( [ text("["), id.pp, text("] "), text(s), text(" ("), e.pp, text(")") ] ); 
+  top.pp = ppConcat( [ text("["), id.pp, text("] "), text(s), text(" ("), e.pp, text(")") ] ); 
   top.freeVariables = e.freeVariables;
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
@@ -1,7 +1,7 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax;
 
 imports silver:langutil;
-imports silver:langutil:pp with implode as ppImplode;
+imports silver:langutil:pp with implode as ppImplode, concat as ppConcat;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Attribute.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Attribute.sv
@@ -17,7 +17,7 @@ abstract production gccAttribute
 top::Attribute ::= l::Attribs
 {
   propagate host, lifted;
-  top.pp = concat([text("__attribute__(("), l.pp, text("))")]);
+  top.pp = ppConcat([text("__attribute__(("), l.pp, text("))")]);
 }
 
 abstract production simpleAsm
@@ -73,7 +73,7 @@ abstract production appliedAttrib
 top::Attrib ::= n::AttribName  e::Exprs
 {
   propagate host, lifted;
-  top.pp = concat([n.pp, parens(ppImplode(text(", "), e.pps))]);
+  top.pp = ppConcat([n.pp, parens(ppImplode(text(", "), e.pps))]);
   top.attribNeedsTrans =
     case n of
       attribName(name("refId")) -> false
@@ -86,7 +86,7 @@ abstract production idAppliedAttrib
 top::Attrib ::= n::AttribName  id::Name  e::Exprs
 {
   propagate host, lifted;
-  top.pp = concat([n.pp, parens(ppImplode(text(", "), id.pp :: e.pps))]);
+  top.pp = ppConcat([n.pp, parens(ppImplode(text(", "), id.pp :: e.pps))]);
   top.attribNeedsTrans = true;
 }
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Debug.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Debug.sv
@@ -72,10 +72,10 @@ e::Expr ::=
 function showEnv
 Document ::= e::Decorated Env
 {
-  return concat( [
+  return ppConcat( [
     text(" Environment:"),
     nestlines(5, 
-      concat([
+      ppConcat([
        --text("Labels:"),line(),
        text("Values:"),line(),
          nestlines(5, valuesD),
@@ -104,15 +104,15 @@ Document ::= scope::[Pair<String a>] showFunc::(Document ::= Pair<String a>)
 function showValueItemBinding
 Document ::= bnd::Pair<String ValueItem>
 {
- return concat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
+ return ppConcat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
 }
 function showTagItemBinding
 Document ::= bnd::Pair<String TagItem>
 {
- return concat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
+ return ppConcat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
 }
 function showRefIdItemBinding
 Document ::= bnd::Pair<String RefIdItem>
 {
- return concat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
+ return ppConcat( [ text(bnd.fst), text(" -> "), nestlines(10,bnd.snd.pp) ]);
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -88,7 +88,7 @@ abstract production defsDecl
 top::Decl ::= d::[Def]
 {
   propagate host;
-  top.pp = concat([pp"/* defsDecl", showEnv(addEnv(d, emptyEnv())), pp"*/"]);
+  top.pp = ppConcat([pp"/* defsDecl", showEnv(addEnv(d, emptyEnv())), pp"*/"]);
   -- This production goes away when lifting occurs
   top.lifted = decls(nilDecl());
   top.errors := [];
@@ -101,7 +101,7 @@ abstract production variableDecls
 top::Decl ::= storage::[StorageClass]  attrs::[Attribute]  ty::BaseTypeExpr  dcls::Declarators
 {
   propagate host, lifted;
-  top.pp = concat(
+  top.pp = ppConcat(
     terminate(space(), map((.pp), storage)) ::
       ppAttributes(attrs) ::
       [ty.pp, space(), ppImplode(text(", "), dcls.pps), semi()]);
@@ -132,7 +132,7 @@ abstract production typedefDecls
 top::Decl ::= attrs::[Attribute]  ty::BaseTypeExpr  dcls::Declarators
 {
   propagate host, lifted;
-  top.pp = concat([text("typedef "), ppAttributes(attrs), ty.pp, space(), ppImplode(text(", "), dcls.pps), semi()]);
+  top.pp = ppConcat([text("typedef "), ppAttributes(attrs), ty.pp, space(), ppImplode(text(", "), dcls.pps), semi()]);
   top.errors := ty.errors ++ dcls.errors;
   top.globalDecls := ty.globalDecls ++ dcls.globalDecls;
   top.defs := ty.defs ++ dcls.defs;
@@ -169,7 +169,7 @@ abstract production warnDecl
 top::Decl ::= msg::[Message]
 {
   propagate host, lifted;
-  top.pp = concat([text("/*"),
+  top.pp = ppConcat([text("/*"),
     ppImplode(line(), map(text, map((.output), msg))),
     text("*/")]);
   top.errors := msg;
@@ -183,7 +183,7 @@ abstract production staticAssertDecl
 top::Decl ::= e::Expr  s::String
 {
   propagate host, lifted;
-  top.pp = concat([text("_Static_assert("), e.pp, text(", "), text(s), text(");")]);
+  top.pp = ppConcat([text("_Static_assert("), e.pp, text(", "), text(s), text(");")]);
   top.errors := e.errors;
   top.globalDecls := e.globalDecls;
   top.defs := e.defs;
@@ -194,7 +194,7 @@ abstract production fileScopeAsm
 top::Decl ::= s::String
 {
   propagate host, lifted;
-  top.pp = concat([text("asm"), parens(text(s))]);
+  top.pp = ppConcat([text("asm"), parens(text(s))]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];
@@ -243,7 +243,7 @@ top::Declarator ::= name::Name  ty::TypeModifierExpr  attrs::[Attribute]  initia
   top.pps =
     case ty of
 {-      pointerTypeExpr(qs, functionTypeExprWithArgs(result, args, variadic)) ->
-        [concat([
+        [ppConcat([
           ty.lpp,
           parens(cat(name.pp, text("*"))),
           parens(
@@ -253,13 +253,13 @@ top::Declarator ::= name::Name  ty::TypeModifierExpr  attrs::[Attribute]  initia
                 (if variadic then args.pps ++ [text("...")] else args.pps))),
           result.rpp])]
     | pointerTypeExpr(qs, functionTypeExprWithoutArgs(result, ids)) ->
-      [concat([
+      [ppConcat([
         ty.lpp,
         parens(cat(name.pp, text("*"))),
         parens(ppImplode(text(", "),
         map((.pp), ids))),
         result.rpp])]-}
-    | _ -> [concat([ty.lpp, name.pp, ty.rpp, ppAttributesRHS(attrs), initializer.pp])]
+    | _ -> [ppConcat([ty.lpp, name.pp, ty.rpp, ppAttributesRHS(attrs), initializer.pp])]
     end;
   
   top.errors :=
@@ -302,7 +302,7 @@ abstract production functionDecl
 top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::[Attribute]  decls::Decls  body::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([terminate(space(), map((.pp), storage)), terminate( space(), map( (.pp), fnquals ) ),
+  top.pp = ppConcat([terminate(space(), map((.pp), storage)), terminate( space(), map( (.pp), fnquals ) ),
     bty.pp, space(), mty.lpp, name.pp, mty.rpp, ppAttributesRHS(attrs), line(), terminate(cat(semi(), line()), decls.pps),
     text("{"), line(), nestlines(2,body.pp), text("}")]);
   
@@ -380,7 +380,7 @@ abstract production badFunctionDecl
 top::FunctionDecl ::= msg::[Message]
 {
   propagate host, lifted;
-  top.pp = concat([text("/*"),
+  top.pp = ppConcat([text("/*"),
     ppImplode(line(), map(text, map((.output), msg))),
     text("*/")]);
   top.errors := msg;
@@ -430,7 +430,7 @@ abstract production parameterDecl
 top::ParameterDecl ::= storage::[StorageClass]  bty::BaseTypeExpr  mty::TypeModifierExpr  name::MaybeName  attrs::[Attribute]
 {
   propagate host, lifted;
-  top.pp = concat([terminate(space(), map((.pp), storage)),
+  top.pp = ppConcat([terminate(space(), map((.pp), storage)),
     bty.pp, space(), mty.lpp, space(), name.pp, mty.rpp, ppAttributesRHS(attrs)]);
   top.paramname = name.maybename;
   top.typerep = mty.typerep;
@@ -464,7 +464,7 @@ top::StructDecl ::= attrs::[Attribute]  name::MaybeName  dcls::StructItemList
 {
   propagate host, lifted;
   top.maybename = name.maybename;
-  top.pp = concat([text("struct "), ppAttributes(attrs), name.pp,
+  top.pp = ppConcat([text("struct "), ppAttributes(attrs), name.pp,
     -- DEBUGGING
     --text("/*" ++ top.refId ++ "*/"),
     -- END DEBUGGING
@@ -544,7 +544,7 @@ top::UnionDecl ::= attrs::[Attribute]  name::MaybeName  dcls::StructItemList
 {
   propagate host, lifted;
   top.maybename = name.maybename;
-  top.pp = concat([text("union "), ppAttributes(attrs), name.pp, 
+  top.pp = ppConcat([text("union "), ppAttributes(attrs), name.pp, 
     -- DEBUGGING
     --text("/*" ++ top.refId ++ "*/"),
     -- END DEBUGGING
@@ -584,7 +584,7 @@ top::EnumDecl ::= name::MaybeName  dcls::EnumItemList
 {
   propagate host, lifted;
   top.maybename = name.maybename;
-  top.pp = concat([text("enum"), space(), name.pp, space(), text("{"),
+  top.pp = ppConcat([text("enum"), space(), name.pp, space(), text("{"),
     nestlines(2, ppImplode(cat(comma(),line()), dcls.pps)),
     text("}")]);
   top.errors := dcls.errors;
@@ -675,7 +675,7 @@ abstract production structItem
 top::StructItem ::= attrs::[Attribute]  ty::BaseTypeExpr  dcls::StructDeclarators
 {
   propagate host, lifted;
-  top.pp = concat([ppAttributes(attrs), ty.pp, space(), ppImplode(text(", "), dcls.pps)]);
+  top.pp = ppConcat([ppAttributes(attrs), ty.pp, space(), ppImplode(text(", "), dcls.pps)]);
   top.errors := ty.errors ++ dcls.errors;
   top.globalDecls := ty.globalDecls ++ dcls.globalDecls;
   top.defs := ty.defs;
@@ -733,7 +733,7 @@ abstract production structField
 top::StructDeclarator ::= name::Name  ty::TypeModifierExpr  attrs::[Attribute]
 {
   propagate host, lifted;
-  top.pps = [concat([ty.lpp, name.pp, ty.rpp, ppAttributesRHS(attrs)])];
+  top.pps = [ppConcat([ty.lpp, name.pp, ty.rpp, ppAttributesRHS(attrs)])];
   top.errors := ty.errors;
   top.globalDecls := ty.globalDecls;
   top.localdefs := [valueDef(name.name, fieldValueItem(top))];
@@ -750,7 +750,7 @@ abstract production structBitfield
 top::StructDeclarator ::= name::MaybeName  ty::TypeModifierExpr  e::Expr  attrs::[Attribute]
 {
   propagate host, lifted;
-  top.pps = [concat([ty.lpp, name.pp, ty.rpp, text(" : "), e.pp, ppAttributesRHS(attrs)])];
+  top.pps = [ppConcat([ty.lpp, name.pp, ty.rpp, text(" : "), e.pp, ppAttributesRHS(attrs)])];
   top.errors := ty.errors ++ e.errors;
   top.globalDecls := ty.globalDecls ++ e.globalDecls;
 
@@ -793,7 +793,7 @@ abstract production enumItem
 top::EnumItem ::= name::Name  e::MaybeExpr
 {
   propagate host, lifted;
-  top.pp = concat([name.pp] ++ if e.isJust then [text(" = "), e.pp] else []);
+  top.pp = ppConcat([name.pp] ++ if e.isJust then [text(" = "), e.pp] else []);
   top.errors := e.errors;
   top.globalDecls := e.globalDecls;
   top.defs := [valueDef(name.name, enumValueItem(top))];

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Expr.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Expr.sv
@@ -24,7 +24,7 @@ abstract production errorExpr
 top::Expr ::= msg::[Message]
 {
   propagate host, lifted;
-  top.pp = concat([ text("/*"), text(messagesToString(msg)), text("*/") ]);
+  top.pp = ppConcat([ text("/*"), text(messagesToString(msg)), text("*/") ]);
   top.errors := msg;
   top.globalDecls := [];
   top.defs := [];
@@ -35,7 +35,7 @@ abstract production warnExpr
 top::Expr ::= msg::[Message] e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([ text("/*"), text(messagesToString(msg)), text("*/"), e.pp ]);
+  top.pp = ppConcat([ text("/*"), text(messagesToString(msg)), text("*/"), e.pp ]);
   top.errors <- msg;
   forwards to e;
 }
@@ -93,7 +93,7 @@ abstract production unaryExprOrTypeTraitExpr
 top::Expr ::= op::UnaryTypeOp  e::ExprOrTypeName
 {
   propagate host, lifted;
-  top.pp = parens( concat([op.pp,parens(e.pp)]) );
+  top.pp = parens( ppConcat([op.pp,parens(e.pp)]) );
   top.errors := op.errors ++ e.errors;
   top.globalDecls := e.globalDecls;
   top.defs := e.defs;
@@ -104,7 +104,7 @@ abstract production arraySubscriptExpr
 top::Expr ::= lhs::Expr  rhs::Expr
 {
   propagate host, lifted;
-  top.pp = parens( concat([ lhs.pp, brackets( rhs.pp )]) );
+  top.pp = parens( ppConcat([ lhs.pp, brackets( rhs.pp )]) );
   top.errors := lhs.errors ++ rhs.errors;
   top.globalDecls := lhs.globalDecls ++ rhs.globalDecls;
   top.defs := lhs.defs ++ rhs.defs;
@@ -137,7 +137,7 @@ abstract production directCallExpr
 top::Expr ::= f::Name  a::Exprs
 {
   -- Forwarding depends on env. We must be able to compute a pp without using env.
-  top.pp = parens( concat([ f.pp, parens( ppImplode( cat( comma(), space() ), a.pps ))]) );
+  top.pp = parens( ppConcat([ f.pp, parens( ppImplode( cat( comma(), space() ), a.pps ))]) );
 
   forwards to f.valueItem.directCallHandler(f, a, top.location);
 }
@@ -155,7 +155,7 @@ abstract production callExpr
 top::Expr ::= f::Expr  a::Exprs
 {
   propagate host, lifted;
-  top.pp = parens( concat([ f.pp, parens( ppImplode( cat( comma(), space() ), a.pps ))]) );
+  top.pp = parens( ppConcat([ f.pp, parens( ppImplode( cat( comma(), space() ), a.pps ))]) );
   top.errors := f.errors ++ a.errors;
   top.globalDecls := f.globalDecls ++ a.globalDecls;
   top.defs := f.defs ++ a.defs;
@@ -199,7 +199,7 @@ abstract production memberExpr
 top::Expr ::= lhs::Expr  deref::Boolean  rhs::Name
 {
   propagate host, lifted;
-  top.pp = parens(concat([lhs.pp, text(if deref then "->" else "."), rhs.pp]));
+  top.pp = parens(ppConcat([lhs.pp, text(if deref then "->" else "."), rhs.pp]));
   top.errors := lhs.errors;
   top.globalDecls := lhs.globalDecls;
   top.defs := lhs.defs;
@@ -248,7 +248,7 @@ top::Expr ::= lhs::Expr  op::BinOp  rhs::Expr
   propagate host, lifted;
   -- case op here is a potential problem, since that emits a dep on op->forward, which eventually should probably include env
   -- Find a way to do this that doesn't cause problems if an op forwards.
-  top.pp = parens( concat([ 
+  top.pp = parens( ppConcat([ 
     {-case op, lhs.pp of
     | assignOp(eqOp()), cat(cat(text("("), lhsNoParens), text(")")) -> lhsNoParens
     | _, _ -> lhs.pp
@@ -270,7 +270,7 @@ abstract production conditionalExpr
 top::Expr ::= cond::Expr  t::Expr  e::Expr
 {
   propagate host, lifted;
-  top.pp = parens( concat([ cond.pp, space(), text("?"), space(), t.pp, space(), text(":"),  space(), e.pp]) );
+  top.pp = parens( ppConcat([ cond.pp, space(), text("?"), space(), t.pp, space(), text(":"),  space(), e.pp]) );
   top.errors := cond.errors ++ t.errors ++ e.errors;
   top.globalDecls := cond.globalDecls ++ t.globalDecls ++ e.globalDecls;
   top.defs := cond.defs ++ t.defs ++ e.defs;
@@ -290,7 +290,7 @@ abstract production binaryConditionalExpr -- GCC extension.
 top::Expr ::= cond::Expr  e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([ cond.pp, space(), text("?:"), space(), e.pp]);
+  top.pp = ppConcat([ cond.pp, space(), text("?:"), space(), e.pp]);
   top.errors := cond.errors ++ e.errors;
   top.globalDecls := cond.globalDecls ++ e.globalDecls;
   top.defs := cond.defs ++ e.defs;
@@ -304,7 +304,7 @@ abstract production explicitCastExpr
 top::Expr ::= ty::TypeName  e::Expr
 {
   propagate host, lifted;
-  top.pp = parens( concat([parens(ty.pp), e.pp]) );
+  top.pp = parens( ppConcat([parens(ty.pp), e.pp]) );
   top.errors := ty.errors ++ e.errors;
   top.globalDecls := ty.globalDecls ++ e.globalDecls;
   top.defs := ty.defs ++ e.defs;
@@ -319,7 +319,7 @@ abstract production compoundLiteralExpr
 top::Expr ::= ty::TypeName  init::InitList
 {
   propagate host, lifted;
-  top.pp = parens( concat([parens(ty.pp), text("{"), ppImplode(text(", "), init.pps), text("}")]) );
+  top.pp = parens( ppConcat([parens(ty.pp), text("{"), ppImplode(text(", "), init.pps), text("}")]) );
   top.errors := ty.errors ++ init.errors;
   top.globalDecls := ty.globalDecls ++ init.globalDecls;
   top.defs := ty.defs ++ init.defs;
@@ -347,7 +347,7 @@ abstract production genericSelectionExpr
 top::Expr ::= e::Expr  gl::GenericAssocs  def::MaybeExpr
 {
   propagate host, lifted;
-  top.pp = concat([text("_Generic"),
+  top.pp = ppConcat([text("_Generic"),
     parens(ppImplode(text(", "), e.pp :: gl.pps ++
       if def.isJust then
         [text("default: "), def.pp]
@@ -406,7 +406,7 @@ abstract production genericAssoc
 top::GenericAssoc ::= ty::TypeName  fun::Expr
 {
   propagate host, lifted;
-  top.pp = concat([ty.pp, text(": "), fun.pp]);
+  top.pp = ppConcat([ty.pp, text(": "), fun.pp]);
   top.errors := ty.errors ++ fun.errors;
   top.globalDecls := ty.globalDecls ++ fun.globalDecls;
   top.defs := ty.defs ++ fun.defs;
@@ -420,7 +420,7 @@ abstract production stmtExpr
 top::Expr ::= body::Stmt result::Expr
 {
   propagate host, lifted;
-  top.pp = concat([text("({"), nestlines(2, concat([body.pp, line(), result.pp, text("; })")]))]);
+  top.pp = ppConcat([text("({"), nestlines(2, ppConcat([body.pp, line(), result.pp, text("; })")]))]);
   top.errors := body.errors ++ result.errors;
   top.globalDecls := body.globalDecls ++ result.globalDecls;
   top.defs := globalDeclsDefs(body.globalDecls) ++ globalDeclsDefs(result.globalDecls); -- defs are *not* propagated up. This is beginning of a scope.
@@ -436,7 +436,7 @@ abstract production comment
 top::Expr ::= s::String
 {
   propagate host, lifted;
-  top.pp = concat([ text("/* "), text(s), text(" */") ]);
+  top.pp = ppConcat([ text("/* "), text(s), text(" */") ]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];

--- a/edu.umn.cs.melt.ableC/abstractsyntax/ExprBuiltins.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/ExprBuiltins.sv
@@ -4,7 +4,7 @@ abstract production typesCompatibleExpr
 top::Expr ::= l::TypeName  r::TypeName
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_types_compatible_p("), l.pp, text(", "), r.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_types_compatible_p("), l.pp, text(", "), r.pp, text(")")]);
   top.errors := l.errors ++ r.errors;
   top.globalDecls := l.globalDecls ++ r.globalDecls;
   top.defs := l.defs ++ r.defs;
@@ -15,7 +15,7 @@ abstract production vaArgExpr
 top::Expr ::= e::Expr  ty::TypeName
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_va_arg("), e.pp, text(", "), ty.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_va_arg("), e.pp, text(", "), ty.pp, text(")")]);
   top.errors := e.errors ++ ty.errors;
   top.globalDecls := e.globalDecls ++ ty.globalDecls;
   top.defs := e.defs ++ ty.defs;
@@ -27,7 +27,7 @@ abstract production offsetofExpr
 top::Expr ::= ty::TypeName  e::MemberDesignator
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_offsetof("), ty.pp, text(", "), e.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_offsetof("), ty.pp, text(", "), e.pp, text(")")]);
   top.errors := ty.errors ++ e.errors;
   top.globalDecls := ty.globalDecls ++ e.globalDecls;
   top.defs := ty.defs ++ e.defs;
@@ -51,7 +51,7 @@ abstract production fieldMemberDesignator
 top::MemberDesignator ::= d::MemberDesignator  id::Name
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("."), id.pp]);
+  top.pp = ppConcat([d.pp, text("."), id.pp]);
   top.errors := d.errors;
   top.globalDecls := d.globalDecls;
   top.defs := d.defs;
@@ -61,7 +61,7 @@ abstract production derefMemberDesignator
 top::MemberDesignator ::= d::MemberDesignator  id::Name
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("->"), id.pp]);
+  top.pp = ppConcat([d.pp, text("->"), id.pp]);
   top.errors := d.errors;
   top.globalDecls := d.globalDecls;
   top.defs := d.defs;
@@ -71,7 +71,7 @@ abstract production arrayMemberDesignator
 top::MemberDesignator ::= d::MemberDesignator  e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("["), e.pp, text("]")]);
+  top.pp = ppConcat([d.pp, text("["), e.pp, text("]")]);
   top.errors := d.errors;
   top.globalDecls := d.globalDecls ++ e.globalDecls;
   top.defs := d.defs ++ e.defs; -- sigh
@@ -82,7 +82,7 @@ abstract production isConstantExpr
 top::Expr ::= e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_constant_p("), e.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_constant_p("), e.pp, text(")")]);
   top.errors := e.errors;
   top.defs := e.defs;
   top.globalDecls := e.globalDecls;
@@ -106,7 +106,7 @@ abstract production expectExpr
 top::Expr ::= eval::Expr  expected::Expr
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_expect("), eval.pp, text(", "), expected.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_expect("), eval.pp, text(", "), expected.pp, text(")")]);
   top.errors := eval.errors ++ expected.errors;
   top.globalDecls := eval.globalDecls ++ expected.globalDecls;
   top.defs := eval.defs ++ expected.defs;
@@ -118,7 +118,7 @@ abstract production vaStartExpr
 top::Expr ::= lastParam::Name  valist::Name
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_va_start("), lastParam.pp, text(", "), valist.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_va_start("), lastParam.pp, text(", "), valist.pp, text(")")]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];
@@ -129,7 +129,7 @@ abstract production vaEndExpr
 top::Expr ::= valist::Name
 {
   propagate host, lifted;
-  top.pp = concat([text("__builtin_va_end("), valist.pp, text(")")]);
+  top.pp = ppConcat([text("__builtin_va_end("), valist.pp, text(")")]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Initializer.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Initializer.sv
@@ -15,7 +15,7 @@ abstract production justInitializer
 top::MaybeInitializer ::= i::Initializer
 {
   propagate host, lifted;
-  top.pp = concat([ text(" = "), i.pp ]);
+  top.pp = ppConcat([ text(" = "), i.pp ]);
   top.errors := i.errors;
   top.globalDecls := i.globalDecls;
   top.defs := i.defs;
@@ -39,7 +39,7 @@ abstract production objectInitializer
 top::Initializer ::= l::InitList
 {
   propagate host, lifted;
-  top.pp = concat([text("{"), ppImplode(text(", "), l.pps), text("}")]);
+  top.pp = ppConcat([text("{"), ppImplode(text(", "), l.pps), text("}")]);
   top.errors := l.errors;
   top.globalDecls := l.globalDecls;
   top.defs := l.defs;
@@ -89,7 +89,7 @@ abstract production designatedInit
 top::Init ::= d::Designator  i::Initializer
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text(" = "), i.pp]);
+  top.pp = ppConcat([d.pp, text(" = "), i.pp]);
   top.errors := d.errors ++ i.errors;
   top.globalDecls := d.globalDecls ++ i.globalDecls;
   top.defs := d.defs ++ i.defs;
@@ -119,7 +119,7 @@ abstract production fieldDesignator
 top::Designator ::= d::Designator  f::Name
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("."), f.pp]);
+  top.pp = ppConcat([d.pp, text("."), f.pp]);
   top.errors := d.errors;
   top.globalDecls := d.globalDecls;
   top.defs := d.defs;
@@ -130,7 +130,7 @@ abstract production arrayDesignator
 top::Designator ::= d::Designator  e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("["), e.pp, text("]")]);
+  top.pp = ppConcat([d.pp, text("["), e.pp, text("]")]);
   top.errors := d.errors ++ e.errors;
   top.globalDecls := d.globalDecls ++ e.globalDecls;
   top.defs := d.defs ++ e.defs; -- Yep...
@@ -144,7 +144,7 @@ abstract production arrayRangeDesignator
 top::Designator ::= d::Designator  l::Expr  u::Expr
 {
   propagate host, lifted;
-  top.pp = concat([d.pp, text("["), l.pp, text("..."), u.pp, text("]")]);
+  top.pp = ppConcat([d.pp, text("["), l.pp, text("..."), u.pp, text("]")]);
   top.errors := d.errors ++ l.errors ++ u.errors;
   top.globalDecls := d.globalDecls ++ l.globalDecls ++ u.globalDecls;
   top.defs := d.defs ++ l.defs ++ u.defs;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Stmt.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Stmt.sv
@@ -20,7 +20,7 @@ abstract production seqStmt
 top::Stmt ::= h::Stmt  t::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ h.pp, line(), t.pp ]);
+  top.pp = ppConcat([ h.pp, line(), t.pp ]);
   top.errors := h.errors ++ t.errors;
   top.globalDecls := h.globalDecls ++ t.globalDecls;
   top.defs := h.defs ++ t.defs;
@@ -109,7 +109,7 @@ abstract production ifStmt
 top::Stmt ::= c::Expr  t::Stmt  e::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([
+  top.pp = ppConcat([
     text("if"), space(), parens(c.pp), line(),
     braces(nestlines(2, t.pp)),
     text(" else "), braces(nestlines(2, e.pp))]);
@@ -138,7 +138,7 @@ top::Stmt ::= c::Expr  t::Stmt  e::Stmt
 abstract production ifStmtNoElse
 top::Stmt ::= c::Expr  t::Stmt
 {
-  top.pp = concat([
+  top.pp = ppConcat([
     text("if"), space(), parens(c.pp), line(),
     braces(nestlines(2, t.pp)) ]);
   forwards to ifStmt(c, t, nullStmt());
@@ -148,7 +148,7 @@ abstract production whileStmt
 top::Stmt ::= e::Expr  b::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ text("while"), space(), parens(e.pp), line(), 
+  top.pp = ppConcat([ text("while"), space(), parens(e.pp), line(), 
                     braces(nestlines(2, b.pp)) ]);
   top.errors := e.errors ++ b.errors;
   top.globalDecls := e.globalDecls ++ b.globalDecls;
@@ -174,7 +174,7 @@ abstract production doStmt
 top::Stmt ::= b::Stmt  e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([ text("do"),  line(), 
+  top.pp = ppConcat([ text("do"),  line(), 
                     braces(nestlines(2,b.pp)), line(), 
                     text("while"), space(), parens(e.pp), semi()]);
   top.errors := b.errors ++ e.errors;
@@ -202,7 +202,7 @@ top::Stmt ::= i::MaybeExpr  c::MaybeExpr  s::MaybeExpr  b::Stmt
 {
   propagate host, lifted;
   top.pp = 
-    concat([text("for"), parens(concat([i.pp, semi(), space(), c.pp, semi(), space(), s.pp])), line(),
+    ppConcat([text("for"), parens(ppConcat([i.pp, semi(), space(), c.pp, semi(), space(), s.pp])), line(),
       braces(nestlines(2, b.pp)) ]);
   top.errors := i.errors ++ c.errors ++ s.errors ++ b.errors;
   top.globalDecls := i.globalDecls ++ c.globalDecls ++ s.globalDecls ++ b.globalDecls;
@@ -237,7 +237,7 @@ abstract production forDeclStmt
 top::Stmt ::= i::Decl  c::MaybeExpr  s::MaybeExpr  b::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ text("for"), space(), parens( concat([ i.pp, space(), c.pp, semi(), space(), s.pp]) ), 
+  top.pp = ppConcat([ text("for"), space(), parens( ppConcat([ i.pp, space(), c.pp, semi(), space(), s.pp]) ), 
                     line(), braces(nestlines(2, b.pp)) ]);
   top.errors := i.errors ++ c.errors ++ s.errors ++ b.errors;
   top.globalDecls := i.globalDecls ++ c.globalDecls ++ s.globalDecls ++ b.globalDecls;
@@ -273,7 +273,7 @@ abstract production returnStmt
 top::Stmt ::= e::MaybeExpr
 {
   propagate host, lifted;
-  top.pp = concat([text("return"), space(), e.pp, semi()]);
+  top.pp = ppConcat([text("return"), space(), e.pp, semi()]);
   top.errors := case top.returnType, e.maybeTyperep of
                   nothing(), nothing() -> []
                 | just(builtinType(_, voidType())), nothing() -> []
@@ -295,7 +295,7 @@ abstract production switchStmt
 top::Stmt ::= e::Expr  b::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ text("switch"), space(), parens(e.pp),  line(), 
+  top.pp = ppConcat([ text("switch"), space(), parens(e.pp),  line(), 
                     braces(nestlines(2, b.pp)) ]);
   top.errors := e.errors ++ b.errors;
   top.globalDecls := e.globalDecls ++ b.globalDecls;
@@ -321,7 +321,7 @@ abstract production gotoStmt
 top::Stmt ::= l::Name
 {
   propagate host, lifted;
-  top.pp = concat([ text("goto"), space(), l.pp, semi() ]);
+  top.pp = ppConcat([ text("goto"), space(), l.pp, semi() ]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];
@@ -347,7 +347,7 @@ abstract production breakStmt
 top::Stmt ::=
 {
   propagate host, lifted;
-  top.pp = concat([ text("break"), semi()  ]);
+  top.pp = ppConcat([ text("break"), semi()  ]);
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];
@@ -359,7 +359,7 @@ abstract production labelStmt
 top::Stmt ::= l::Name  s::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ l.pp, text(":"), space(), s.pp]);
+  top.pp = ppConcat([ l.pp, text(":"), space(), s.pp]);
   top.errors := s.errors;
   top.globalDecls := s.globalDecls;
   top.defs := s.defs;
@@ -373,7 +373,7 @@ abstract production caseLabelStmt
 top::Stmt ::= v::Expr  s::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([text("case"), space(), v.pp, text(":"), nestlines(2,s.pp)]); 
+  top.pp = ppConcat([text("case"), space(), v.pp, text(":"), nestlines(2,s.pp)]); 
   top.errors := v.errors ++ s.errors;
   top.globalDecls := v.globalDecls ++ s.globalDecls;
   top.defs := v.defs ++ s.defs;
@@ -389,7 +389,7 @@ abstract production defaultLabelStmt
 top::Stmt ::= s::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([ text("default"), text(":"), nestlines(2,s.pp)]);
+  top.pp = ppConcat([ text("default"), text(":"), nestlines(2,s.pp)]);
   top.errors := s.errors;
   top.globalDecls := s.globalDecls;
   top.defs := s.defs;
@@ -415,7 +415,7 @@ abstract production caseLabelRangeStmt
 top::Stmt ::= l::Expr  u::Expr  s::Stmt
 {
   propagate host, lifted;
-  top.pp = concat([text("case"), space(), l.pp, text("..."), u.pp, text(":"), space(),s.pp]); 
+  top.pp = ppConcat([text("case"), space(), l.pp, text("..."), u.pp, text(":"), space(),s.pp]); 
   top.errors := l.errors ++ u.errors ++ s.errors;
   top.globalDecls := l.globalDecls ++ u.globalDecls ++ s.globalDecls;
   top.defs := l.defs ++ u.defs ++ s.defs;
@@ -454,7 +454,7 @@ top::Stmt ::=
 abstract production blockCommentStmt
 top::Stmt ::= c::Document
 {
-  top.pp = concat([ text("/* "), c, text(" */") ]);
+  top.pp = ppConcat([ text("/* "), c, text(" */") ]);
   top.errors := [];
   top.defs := [];
   top.functiondefs := [];

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeExprs.sv
@@ -56,7 +56,7 @@ abstract production typeName
 top::TypeName ::= bty::BaseTypeExpr  mty::TypeModifierExpr
 {
   propagate host, lifted;
-  top.pp = concat([bty.pp, mty.lpp, mty.rpp]);
+  top.pp = ppConcat([bty.pp, mty.lpp, mty.rpp]);
   top.typerep = mty.typerep;
   top.bty = bty;
   top.mty = mty;
@@ -131,7 +131,7 @@ abstract production typeModifierTypeExpr
 top::BaseTypeExpr ::= bty::BaseTypeExpr  mty::TypeModifierExpr
 {
   propagate host;
-  top.pp = parens(concat([bty.pp, mty.lpp, mty.rpp]));
+  top.pp = parens(ppConcat([bty.pp, mty.lpp, mty.rpp]));
   top.lifted = bty.lifted;
   top.typerep = mty.typerep;
   mty.baseType = bty.typerep;
@@ -162,7 +162,7 @@ abstract production tagReferenceTypeExpr
 top::BaseTypeExpr ::= q::[Qualifier]  kwd::StructOrEnumOrUnion  name::Name
 {
   propagate host, lifted;
-  top.pp = concat([terminate( space(), map( (.pp), q ) ), kwd.pp, space(), name.pp
+  top.pp = ppConcat([terminate( space(), map( (.pp), q ) ), kwd.pp, space(), name.pp
     -- DEBUGGING
     --, text("/*" ++ refId ++ "*/")
     -- END DEBUGGING
@@ -239,7 +239,7 @@ abstract production structTypeExpr
 top::BaseTypeExpr ::= q::[Qualifier]  def::StructDecl
 {
   propagate host, lifted;
-  top.pp = concat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
+  top.pp = ppConcat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
   local name :: String = 
     case def.maybename of
     | just(n) -> n.name
@@ -258,7 +258,7 @@ abstract production unionTypeExpr
 top::BaseTypeExpr ::= q::[Qualifier]  def::UnionDecl
 {
   propagate host, lifted;
-  top.pp = concat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
+  top.pp = ppConcat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
   local name :: String = 
     case def.maybename of
     | just(n) -> n.name
@@ -277,7 +277,7 @@ abstract production enumTypeExpr
 top::BaseTypeExpr ::= q::[Qualifier]  def::EnumDecl
 {
   propagate host, lifted;
-  top.pp = concat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
+  top.pp = ppConcat([ terminate( space(), map( (.pp), q ) ), def.pp ]);
   top.typerep = tagType(q, enumTagType(def));
   top.errors := def.errors;
   top.globalDecls := def.globalDecls;
@@ -291,7 +291,7 @@ abstract production typedefTypeExpr
 top::BaseTypeExpr ::= q::[Qualifier]  name::Name
 {
   propagate host, lifted;
-  top.pp = concat([ terminate( space(), map( (.pp), q ) ), name.pp ]);
+  top.pp = ppConcat([ terminate( space(), map( (.pp), q ) ), name.pp ]);
 
   top.typerep = 
     if !null(name.valueLookupCheck) then errorType()
@@ -313,7 +313,7 @@ top::BaseTypeExpr ::= q::[Qualifier]  wrapped::TypeName
 {
   top.typerep = atomicType(q, wrapped.typerep);
   propagate host, lifted;
-  top.pp = concat([ ppImplode( space(), map( (.pp), q)), space(),
+  top.pp = ppConcat([ ppImplode( space(), map( (.pp), q)), space(),
                      text("_Atomic"), parens(wrapped.pp)]);
   top.errors := wrapped.errors;
   top.globalDecls := wrapped.globalDecls;
@@ -341,7 +341,7 @@ top::BaseTypeExpr ::= q::[Qualifier]  e::ExprOrTypeName
 {
   top.typerep = noncanonicalType(typeofType(q, e.typerep));
   propagate host, lifted;
-  top.pp = concat([text("__typeof__"), parens(e.pp)]);
+  top.pp = ppConcat([text("__typeof__"), parens(e.pp)]);
   top.errors := e.errors;
   top.globalDecls := e.globalDecls;
   top.typeModifiers = [];
@@ -387,7 +387,7 @@ abstract production pointerTypeExpr
 top::TypeModifierExpr ::= q::[Qualifier]  target::TypeModifierExpr
 {
   propagate host, lifted;
-  top.lpp = concat([ target.lpp, space(),
+  top.lpp = ppConcat([ target.lpp, space(),
                      case target of
                        functionTypeExprWithArgs(_, _, _) -> text("(*)")
                      | functionTypeExprWithoutArgs(_, _) -> text("(*)")
@@ -407,7 +407,7 @@ top::TypeModifierExpr ::= element::TypeModifierExpr  indexQualifiers::[Qualifier
   propagate host, lifted;
   top.lpp = element.lpp;
   
-  top.rpp = cat(brackets(concat([
+  top.rpp = cat(brackets(ppConcat([
     terminate(space(), map((.pp), indexQualifiers) ++ sizeModifier.pps), 
     size.pp
     ])), element.rpp);
@@ -440,7 +440,7 @@ abstract production functionTypeExprWithArgs
 top::TypeModifierExpr ::= result::TypeModifierExpr  args::Parameters  variadic::Boolean
 {
   propagate host, lifted;
-  top.lpp = concat([ result.lpp ]);
+  top.lpp = ppConcat([ result.lpp ]);
 
   top.rpp = 
     cat(parens(

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
@@ -68,6 +68,6 @@ abstract production alignasSpecifier
 top::SpecialSpecifier ::= e::Expr
 {
   propagate host, lifted;
-  top.pp = concat([text("_Alignas"), parens(e.pp)]);
+  top.pp = ppConcat([text("_Alignas"), parens(e.pp)]);
 --  top.errors := e.errors;
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Types.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Types.sv
@@ -82,7 +82,7 @@ top::Type ::= q::[Qualifier]  bt::BuiltinType
 {
   propagate host;
   top.lpp =
-    concat([terminate(space(), map((.pp), q)),
+    ppConcat([terminate(space(), map((.pp), q)),
             bt.pp]);
   top.rpp = notext();
   top.baseTypeExpr = builtinTypeExpr(q, bt);
@@ -109,7 +109,7 @@ abstract production pointerType
 top::Type ::= q::[Qualifier]  target::Type
 {
   propagate host;
-  top.lpp = concat([ target.lpp, space(), ppImplode( space(), map( (.pp), q ) ),
+  top.lpp = ppConcat([ target.lpp, space(), ppImplode( space(), map( (.pp), q ) ),
                      text("*") ]);
   top.rpp = target.rpp;
   top.baseTypeExpr = target.baseTypeExpr;
@@ -152,7 +152,7 @@ top::Type ::= element::Type  indexQualifiers::[Qualifier]  sizeModifier::ArraySi
   propagate host;
   top.lpp = element.lpp;
   
-  top.rpp = cat(brackets(concat([
+  top.rpp = cat(brackets(ppConcat([
     terminate(space(), map((.pp), indexQualifiers) ++ sizeModifier.pps),
     sub.pp
     ])), element.rpp);
@@ -234,7 +234,7 @@ top::Type ::= result::Type  sub::FunctionType
 {
   propagate host;
   --TODO should this space be here? also TODO: ordering? result lpp before sub.lpp maybe? TODO: actually sub.lpp is always nothing. FIXME
-  top.lpp = concat([ sub.lpp, space(), result.lpp ]);
+  top.lpp = ppConcat([ sub.lpp, space(), result.lpp ]);
   top.rpp = cat(sub.rpp, result.rpp);
   top.baseTypeExpr = result.baseTypeExpr;
   top.typeModifierExpr =
@@ -305,7 +305,7 @@ abstract production tagType
 top::Type ::= q::[Qualifier]  sub::TagType
 {
   propagate host;
-  top.lpp = concat([ terminate( space(), map( (.pp), q ) ), sub.pp ]);
+  top.lpp = ppConcat([ terminate( space(), map( (.pp), q ) ), sub.pp ]);
   top.rpp = notext();
   top.baseTypeExpr =
     case sub of
@@ -358,7 +358,7 @@ abstract production refIdTagType
 top::TagType ::= kwd::StructOrEnumOrUnion  name::String  refId::String
 {
   propagate host;
-  top.pp = concat([kwd.pp, space(), text(name)]);
+  top.pp = ppConcat([kwd.pp, space(), text(name)]);
   top.mangledName = s"${kwd.mangledName}_${name}_${substitute(":", "_", refId)}";
   top.isIntegerType = false;
 }
@@ -379,7 +379,7 @@ abstract production atomicType
 top::Type ::= q::[Qualifier]  bt::Type
 {
   propagate host;
-  top.lpp = concat([ ppImplode( space(), map( (.pp), q)), space(),
+  top.lpp = ppConcat([ ppImplode( space(), map( (.pp), q)), space(),
                      text("_Atomic"), parens(cat(bt.lpp, bt.rpp))]);
   top.rpp = notext();
   top.mangledName = s"atomic_${implode("_", map((.qualname), q))}_${bt.mangledName}_";
@@ -401,7 +401,7 @@ abstract production vectorType
 top::Type ::= bt::Type  bytes::Integer
 {
   propagate host;
-  top.lpp = concat([ text("__attribute__((__vector_size__(" ++ toString(bytes) ++ "))) "), bt.lpp]);
+  top.lpp = ppConcat([ text("__attribute__((__vector_size__(" ++ toString(bytes) ++ "))) "), bt.lpp]);
   top.rpp = bt.rpp;
   top.mangledName = s"vector_${bt.mangledName}_${toString(bytes)}_";
   -- TODO: pp doesn't match type expression.  Should involve attributedTypeExpr which isn't a thing
@@ -479,7 +479,7 @@ abstract production parenType
 top::NoncanonicalType ::= wrapped::Type
 {
   propagate host;
-  top.lpp = concat([ wrapped.lpp, space(), text("(") ]);
+  top.lpp = ppConcat([ wrapped.lpp, space(), text("(") ]);
   top.rpp = cat( text(")"), wrapped.rpp );
   top.baseTypeExpr = wrapped.baseTypeExpr;
   top.typeModifierExpr = parenTypeExpr(wrapped.typeModifierExpr);
@@ -528,7 +528,7 @@ abstract production typedefType
 top::NoncanonicalType ::= q::[Qualifier]  n::String  resolved::Type
 {
   propagate host;
-  top.lpp = concat([ terminate( space(), map( (.pp), q ) ), text(n) ]);
+  top.lpp = ppConcat([ terminate( space(), map( (.pp), q ) ), text(n) ]);
   top.rpp = notext();
   top.baseTypeExpr = typedefTypeExpr(q, name(n, location=builtinLoc("host")));
   top.typeModifierExpr = baseTypeExpr();
@@ -542,7 +542,7 @@ top::NoncanonicalType ::= q::[Qualifier]  resolved::Type
 {
   propagate host;
   top.canonicalType = resolved;-- todo: some sort of discipline of what to do with qualifiers here
-  top.lpp = concat([text("__typeof__"), parens(cat(resolved.lpp, resolved.rpp))]);
+  top.lpp = ppConcat([text("__typeof__"), parens(cat(resolved.lpp, resolved.rpp))]);
   top.rpp = notext();
   top.baseTypeExpr =
     typeofTypeExpr(q, typeNameExpr(typeName(resolved.baseTypeExpr, resolved.typeModifierExpr)));

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypesBuiltin.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypesBuiltin.sv
@@ -57,7 +57,7 @@ abstract production complexType
 top::BuiltinType ::= rt::RealType
 {
   propagate host;
-  top.pp = concat([ text("_Complex "), rt.pp ]);
+  top.pp = ppConcat([ text("_Complex "), rt.pp ]);
   top.mangledName = "complex_" ++ rt.mangledName;
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin =
@@ -75,7 +75,7 @@ abstract production imaginaryType
 top::BuiltinType ::= rt::RealType
 {
   propagate host;
-  top.pp = concat([ text("_Imaginary "), rt.pp ]);
+  top.pp = ppConcat([ text("_Imaginary "), rt.pp ]);
   top.mangledName = "imaginary_" ++ rt.mangledName;
   top.integerPromotionsBuiltin = top;
   top.defaultArgumentPromotionsBuiltin =
@@ -93,7 +93,7 @@ abstract production signedType
 top::BuiltinType ::= it::IntegerType
 {
   propagate host;
-  top.pp = concat([ text(signed), it.pp ]);
+  top.pp = ppConcat([ text(signed), it.pp ]);
   local signed :: String =
     case it of
     | charType() -> ""
@@ -118,7 +118,7 @@ abstract production unsignedType
 top::BuiltinType ::= it::IntegerType
 {
   propagate host;
-  top.pp = concat([ text("unsigned "), it.pp ]);
+  top.pp = ppConcat([ text("unsigned "), it.pp ]);
   top.mangledName = "unsigned_" ++ it.mangledName;
   top.integerPromotionsBuiltin = 
     case it of
@@ -136,7 +136,7 @@ abstract production complexIntegerType
 top::BuiltinType ::= it::IntegerType
 {
   propagate host;
-  top.pp = concat([ text("_Complex "), it.pp ]);
+  top.pp = ppConcat([ text("_Complex "), it.pp ]);
   top.mangledName = "complexinteger_" ++ it.mangledName;
   top.integerPromotionsBuiltin = 
     complexIntegerType(


### PR DESCRIPTION
This is a short-term solution. Realistically, we should:

1. Fix `imports` by fixing [Silver issue 139](https://github.com/melt-umn/silver/issues/139).
2. Rename `implode`, `concat`, etc. in `silver:langutil:pp` to `ppImplode`, `ppConcat`, etc., and name all `Document` functions as such.
3. Monoid typeclass?