### PR TITLE
Refactor overloading to utilize aspect functions

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -479,8 +479,9 @@ top::ParameterDecl ::= storage::[StorageClass]  bty::BaseTypeExpr  mty::TypeModi
   top.errors <- name.valueRedeclarationCheckNoCompatible;
 }
 
-
 synthesized attribute refId :: String; -- TODO move this later?
+-- Name of the extension that declared this struct/union
+synthesized attribute moduleName :: Maybe<String>;
 
 nonterminal StructDecl with location, pp, host<StructDecl>, lifted<StructDecl>, maybename, errors, globalDecls, defs, env, tagEnv, givenRefId, refId, moduleName, returnType, freeVariables;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -249,6 +249,7 @@ top::Declarators ::=
 }
 
 nonterminal Declarator with pps, host<Declarator>, lifted<Declarator>, errors, globalDecls, defs, env, baseType, typeModifiersIn, typerep, sourceLocation, isTopLevel, isTypedef, givenAttributes, returnType, freeVariables;
+flowtype Declarator = decorate {env, returnType, baseType, givenAttributes, isTopLevel, isTypedef};
 
 autocopy attribute isTypedef :: Boolean;
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -748,7 +748,7 @@ top::StructDeclarator ::= name::Name  ty::TypeModifierExpr  attrs::Attributes
   top.globalDecls := ty.globalDecls;
   top.localdefs := [valueDef(name.name, fieldValueItem(top))];
   top.freeVariables = ty.freeVariables;
-  top.typerep = ty.typerep;
+  top.typerep = animateAttributeOnType(allAttrs, ty.typerep);
   top.sourceLocation = name.location;
   
   
@@ -771,7 +771,7 @@ top::StructDeclarator ::= name::MaybeName  ty::TypeModifierExpr  e::Expr  attrs:
     end;
   top.localdefs := thisdcl;
   top.freeVariables = ty.freeVariables ++ e.freeVariables;
-  top.typerep = ty.typerep;
+  top.typerep = animateAttributeOnType(allAttrs, ty.typerep);
   top.sourceLocation = 
     case name.maybename of
     | just(n) -> n.location

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeOps.sv
@@ -335,11 +335,16 @@ Type ::= qs::[Qualifier] base::Type
  {
    return
      case a of
-       tagType(_, refIdTagType(_, _, refId)) ->
+     | tagType(_, refIdTagType(_, _, refId)) ->
          case lookupRefId(refId, env) of
-         | item :: _ -> orElse(item.moduleName, a.moduleName)
-         | _ -> error("Undefined refId " ++ refId)
+-- The type is a tag type, with a definition: Check the attributes on the definition for a module name
+         | item :: _ -> item.moduleName
+-- The type is a tag type, without a definition: The type belongs to host
+         | _ -> nothing()
          end
-     | _ -> a.moduleName
+-- The type is an attributed type: Check the attributes for a module name first, then the base type
+     | attributedType(attrs, bt) -> orElse(attrs.moduleName, moduleName(env, bt))
+-- Other types do not have a module name
+     | _ -> nothing()
      end;
  }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Types.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Types.sv
@@ -9,7 +9,7 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax;
  - Variants: builtin, pointer, array, function, tagged, noncanonical.
  - Noncanonical forwards, and so doesn't need any attributes, etc attached to it.
  -}
-nonterminal Type with lpp, rpp, host<Type>, baseTypeExpr, typeModifierExpr, mangledName, moduleName, integerPromotions, defaultArgumentPromotions, defaultLvalueConversion, defaultFunctionArrayLvalueConversion, isIntegerType, isScalarType, isArithmeticType, withoutAttributes, withoutTypeQualifiers, withTypeQualifiers, addedTypeQualifiers;
+nonterminal Type with lpp, rpp, host<Type>, baseTypeExpr, typeModifierExpr, mangledName, integerPromotions, defaultArgumentPromotions, defaultLvalueConversion, defaultFunctionArrayLvalueConversion, isIntegerType, isScalarType, isArithmeticType, withoutAttributes, withoutTypeQualifiers, withTypeQualifiers, addedTypeQualifiers;
 
 -- Used to turn a Type back into a TypeName
 synthesized attribute baseTypeExpr :: BaseTypeExpr;
@@ -17,9 +17,6 @@ synthesized attribute typeModifierExpr :: TypeModifierExpr;
 
 -- Compute a unique name for a type that is a valid C identifier
 synthesized attribute mangledName :: String;
-
--- Name of the extension that declared this type, or nothing() for a host type 
-synthesized attribute moduleName :: Maybe<String>;
 
 -- char -> int and stuff in operations
 synthesized attribute integerPromotions :: Type;
@@ -43,7 +40,6 @@ inherited attribute addedTypeQualifiers :: [Qualifier];
 aspect default production
 top::Type ::=
 {
-  top.moduleName = nothing();
   top.withoutAttributes = top;
   top.withoutTypeQualifiers = top;
   top.withTypeQualifiers = top;
@@ -416,7 +412,6 @@ top::Type ::= attrs::Attributes  bt::Type
   top.lpp = ppConcat([ ppAttributes(attrs), space(), bt.lpp]);
   top.rpp = bt.rpp;
   top.mangledName = bt.mangledName;
-  top.moduleName = orElse(attrs.moduleName, bt.moduleName);
   top.baseTypeExpr = attributedTypeExpr(attrs, bt.baseTypeExpr);
   top.typeModifierExpr = baseTypeExpr();
   top.integerPromotions = attributedType(attrs, bt.integerPromotions);
@@ -448,7 +443,6 @@ top::Type ::= bt::Type  bytes::Integer
   top.lpp = ppConcat([ text("__attribute__((__vector_size__(" ++ toString(bytes) ++ "))) "), bt.lpp]);
   top.rpp = bt.rpp;
   top.mangledName = s"vector_${bt.mangledName}_${toString(bytes)}_";
-  top.moduleName = bt.moduleName;
   -- Translate vectorType
   top.baseTypeExpr =
     attributedTypeExpr(

--- a/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprBinOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprBinOps.sv
@@ -13,7 +13,9 @@ top::BinOp ::= op::AssignOp
 {
   local tmpName::String = "_tmp" ++ toString(genInt());
 
+  -- Option 1: An explicit overload for the assignment operator
   local option1::Maybe<(Expr ::= Expr Expr Location)> = op.binaryProd;
+  -- Option 2: Infer an overload for a compound assignment operator from the base operator
   local option2::Maybe<(Expr ::= Expr Expr Location)> = 
     do (bindMaybe, returnMaybe) {
       baseOp :: BinOp <- op.baseOp;
@@ -183,8 +185,10 @@ top::CompareOp ::=
 aspect production notEqualsOp
 top::CompareOp ::=
 {
+  -- Option 1: An explicit overload for !=
   local option1::Maybe<(Expr ::= Expr Expr Location)> =
     getNotEqualsOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  -- Option 2: Infer an overload for != from an overload for ==
   local option2::Maybe<(Expr ::= Expr Expr Location)> =
     case getEqualsOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
       just(prod) ->
@@ -209,8 +213,10 @@ top::CompareOp ::=
 aspect production gteOp
 top::CompareOp ::=
 {
+  -- Option 1: An explicit overload for >=
   local option1::Maybe<(Expr ::= Expr Expr Location)> =
     getGteOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  -- Option 2: Infer an overload for >= from an overload for <
   local option2::Maybe<(Expr ::= Expr Expr Location)> =
     case getLtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
       just(prod) ->
@@ -225,8 +231,10 @@ top::CompareOp ::=
 aspect production lteOp
 top::CompareOp ::=
 {
+  -- Option 1: An explicit overload for <=
   local option1::Maybe<(Expr ::= Expr Expr Location)> =
     getLteOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  -- Option 2: Infer an overload for <= from an overload for >
   local option2::Maybe<(Expr ::= Expr Expr Location)> =
     case getGtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
       just(prod) ->

--- a/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprBinOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprBinOps.sv
@@ -1,52 +1,30 @@
-
+grammar edu:umn:cs:melt:ableC:abstractsyntax:overload;
 
 aspect default production
 top::BinOp ::=
 {
-  top.resolved = nothing();
+  top.binaryProd = nothing();
 }
 
 aspect production assignOp
 top::BinOp ::= op::AssignOp
 {
-  production attribute subscriptOverloads::[Pair<String (Expr ::= Expr Expr Expr)>] with ++;
-  production attribute memberOverloads::[Pair<String (Expr ::= Expr Boolean Name Expr)>] with ++;
-  subscriptOverloads := [];
-  memberOverloads := [];
-
-  local option1::Maybe<Expr> =
-    case top.lop of
-      arraySubscriptExpr(l, r) ->
-        do (bindMaybe, returnMaybe) {
-          n :: String <- moduleName(l.env, l.typerep);
-          prod :: (Expr ::= Expr Expr Expr) <- lookupBy(stringEq, n, subscriptOverloads);
-          return prod(l, r, new(top.rop));
-        }
-    | _ -> nothing()
-    end;
-  local option2::Maybe<Expr> = 
-    case top.lop of
-      memberExpr(l, d, r) ->
-        do (bindMaybe, returnMaybe) {
-          n :: String <- moduleName(l.env, l.typerep);
-          prod :: (Expr ::= Expr Boolean Name Expr) <- lookupBy(stringEq, n, memberOverloads);
-          return prod(l, d, r, new(top.rop));
-        }
-    | _ -> nothing()
-    end;
-  local option3::Maybe<Expr> = op.resolved;
-  local option4::Maybe<Expr> = 
-    case op.baseOp of
-      just(baseOp) ->
-        just(
+  local option1::Maybe<(Expr ::= Expr Expr Location)> = op.binaryProd;
+  local option2::Maybe<(Expr ::= Expr Expr Location)> = 
+    do (bindMaybe, returnMaybe) {
+      baseOp :: BinOp <- op.baseOp;
+      baseProd :: (Expr ::= Expr Expr Location) <-
+        decorate baseOp with {lop = top.lop; rop = top.rop;}.binaryProd;
+      return
+        \ lhs::Expr rhs::Expr loc::Location ->
+          -- TODO: Slight bug here, lhs is used twice
           binaryOpExpr(
-            new(top.lop),
-            assignOp(eqOp(location=top.location), location=top.location),
-            binaryOpExpr(new(top.lop), baseOp, new(top.rop), location=top.location),
-          location=top.location))
-    | nothing() -> nothing()
-    end;
-  top.resolved = orElse(option1, orElse(option2, orElse(option3, option4)));
+            lhs,
+            assignOp(eqOp(location=loc), location=loc),
+            baseProd(lhs, rhs, loc),
+          location=loc);
+    };
+  top.binaryProd = orElse(option1, option2);
 }
 
 synthesized attribute baseOp::Maybe<BinOp> occurs on AssignOp;
@@ -55,155 +33,67 @@ aspect production eqOp
 top::AssignOp ::=
 {
   top.baseOp = nothing();
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production mulEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(numOp(mulOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getMulEqAssignOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production divEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(numOp(divOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getDivEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production modEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(numOp(modOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getModEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production addEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(numOp(addOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getAddEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production subEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(numOp(subOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getSubEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production lshEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(bitOp(lshBitOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getLshEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production rshEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(bitOp(rshBitOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getRshEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production andEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(bitOp(andBitOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getAndEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production orEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(bitOp(orBitOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getOrEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production xorEqOp
 top::AssignOp ::=
 {
   top.baseOp = just(bitOp(xorBitOp(location=top.location), location=top.location));
-  
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getXorEqOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 
 --------------------------------------------------------------------------------
@@ -212,216 +102,122 @@ top::AssignOp ::=
 aspect production boolOp
 top::BinOp ::= op::BoolOp
 {
-  top.resolved = op.resolved;
+  top.binaryProd = op.binaryProd;
 }
 
 aspect production andBoolOp
 top::BoolOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getAndBoolOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production orBoolOp
 top::BoolOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getOrBoolOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 
 --------------------------------------------------------------------------------
 aspect production bitOp
 top::BinOp ::= op::BitOp
 {
-  top.resolved = op.resolved;
+  top.binaryProd = op.binaryProd;
 }
 
 aspect production andBitOp
 top::BitOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getAndBitOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production orBitOp
 top::BitOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getOrBitOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production xorBitOp
 top::BitOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getXorBitOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production lshBitOp
 top::BitOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getLshBitOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production rshBitOp
 top::BitOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getRshBitOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 
 --------------------------------------------------------------------------------
 aspect production compareOp
 top::BinOp ::= op::CompareOp
 {
-  top.resolved = op.resolved;
+  top.binaryProd = op.binaryProd;
 }
 
 aspect production equalsOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getEqualsOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production notEqualsOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
+  local option1::Maybe<(Expr ::= Expr Expr Location)> =
+    getNotEqualsOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  local option2::Maybe<(Expr ::= Expr Expr Location)> =
+    case getEqualsOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
+      just(prod) ->
+        just(
+          \ lhs::Expr rhs::Expr loc::Location ->
+            unaryOpExpr(notOp(location=loc), prod(lhs, rhs, loc), location=loc))
+    | nothing() -> nothing()
+    end; 
   
-  local option1::Maybe<Expr> = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
-  local option2::Maybe<Expr> =
-    just(
-      unaryOpExpr(
-        notOp(location=top.location),
-        binaryOpExpr(
-          new(top.lop),
-          compareOp(equalsOp(location=top.location), location=top.location),
-          new(top.rop),
-          location=top.location),
-        location=top.location)); 
-  
-  top.resolved = orElse(option1, option2);
+  top.binaryProd = orElse(option1, option2);
 }
 aspect production gtOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getGtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production ltOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getLtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production gteOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
+  local option1::Maybe<(Expr ::= Expr Expr Location)> =
+    getGteOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  local option2::Maybe<(Expr ::= Expr Expr Location)> =
+    case getLtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
+      just(prod) ->
+        just(
+          \ lhs::Expr rhs::Expr loc::Location ->
+            unaryOpExpr(notOp(location=loc), prod(lhs, rhs, loc), location=loc))
+    | nothing() -> nothing()
+    end; 
   
-  local option1::Maybe<Expr> = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
-  local option2::Maybe<Expr> =
-    just(
-      unaryOpExpr(
-        notOp(location=top.location),
-        binaryOpExpr(
-          new(top.lop),
-          compareOp(ltOp(location=top.location), location=top.location),
-          new(top.rop),
-          location=top.location),
-        location=top.location)); 
-  
-  top.resolved = orElse(option1, option2);
+  top.binaryProd = orElse(option1, option2);
 }
 aspect production lteOp
 top::CompareOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
+  local option1::Maybe<(Expr ::= Expr Expr Location)> =
+    getLteOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
+  local option2::Maybe<(Expr ::= Expr Expr Location)> =
+    case getGtOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env) of
+      just(prod) ->
+        just(
+          \ lhs::Expr rhs::Expr loc::Location ->
+            unaryOpExpr(notOp(location=loc), prod(lhs, rhs, loc), location=loc))
+    | nothing() -> nothing()
+    end; 
   
-  local option1::Maybe<Expr> = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
-  local option2::Maybe<Expr> =
-    just(
-      unaryOpExpr(
-        notOp(location=top.location),
-        binaryOpExpr(
-          new(top.lop),
-          compareOp(gtOp(location=top.location), location=top.location),
-          new(top.rop),
-          location=top.location),
-        location=top.location)); 
-  
-  top.resolved = orElse(option1, option2);
+  top.binaryProd = orElse(option1, option2);
 }
 
 
@@ -429,66 +225,31 @@ top::CompareOp ::=
 aspect production numOp
 top::BinOp ::= op::NumOp
 {
-  top.resolved = op.resolved;
+  top.binaryProd = op.binaryProd;
 }
 
 aspect production addOp
 top::NumOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getAddOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production subOp
 top::NumOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getSubOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production mulOp
 top::NumOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getMulOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production divOp
 top::NumOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getDivOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }
 aspect production modOp
 top::NumOp ::=
 {
-  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>] with ++;
-  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr)>] with ++;
-  overloads := [];
-  lOverloads := [];
-  rOverloads := [];
-  
-  top.resolved = getBinaryOverload(top.lop, top.rop, overloads, lOverloads, rOverloads);
+  top.binaryProd = getModOpOverload(top.lop.typerep, top.rop.typerep, top.lop.env);
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprUnaryOps.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/overload/ExprUnaryOps.sv
@@ -3,76 +3,56 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:overload;
 aspect default production
 top::UnaryOp ::=
 {
-  top.resolved = nothing();
+  top.unaryProd = nothing();
 }
 
 aspect production preIncOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getPreIncOpOverload(top.op.typerep, top.op.env);
 }
 aspect production preDecOp
 top::UnaryOp ::= 
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getPreDecOpOverload(top.op.typerep, top.op.env);
 }
 aspect production postIncOp
 top::UnaryOp ::= 
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getPostIncOpOverload(top.op.typerep, top.op.env);
 }
 aspect production postDecOp
 top::UnaryOp ::= 
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getPostDecOpOverload(top.op.typerep, top.op.env);
 }
 aspect production addressOfOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getAddressOfOpOverload(top.op.typerep, top.op.env);
 }
 aspect production dereferenceOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getDereferenceOpOverload(top.op.typerep, top.op.env);
 }
 aspect production positiveOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getPositiveOpOverload(top.op.typerep, top.op.env);
 }
 aspect production negativeOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getNegativeOpOverload(top.op.typerep, top.op.env);
 }
 aspect production bitNegateOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getBitNegateOpOverload(top.op.typerep, top.op.env);
 }
 aspect production notOp
 top::UnaryOp ::=
 {
-  production attribute overloads::[Pair<String (Expr ::= Expr)>] with ++;
-  overloads := [];
-  top.resolved = getUnaryOverload(top.op, overloads);
+  top.unaryProd = getNotOpOverload(top.op.typerep, top.op.env);
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/overload/OpOverload.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/overload/OpOverload.sv
@@ -18,11 +18,11 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:env;
  - subscripts, and field access.  
  -
  - This method of overloading works by staticly building lists of possible overloads paired with
- - module names via collection production attributes on the dispatching productions.  Here the
- - module name is a unique string based on the grammar name of the extension, which can be set on a
- - type via GCC's `__attribute__` mechanism.  To avoid prevent unexpected behavior, we require all
- - overloaded types to be a 'new' type not compatible with any host types, such as structs, unions,
- - or enums.  
+ - module names via collection production attributes.  Here the module name is a unique string
+ - based on the grammar name of the extension, which can be set on a type via GCC's `__attribute__`
+ - mechanism.  To avoid undefined behavior (similar to 'orphaned instances' in Haskell), we require
+ - all overloaded types to be a 'new' type not compatible with any host types, such as structs,
+ - unions, or enums.  
  -
  - The module name of an operator argument, if set, can be accessed from its typerep via the
  - moduleName attribute and used to look up the forward for a dispatching production.  For binary
@@ -35,55 +35,597 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:env;
  -   struct __attribute__((module("org:ext:foo"))) foo { ... }
  - or
  -   typedef __attribute__((module("org:ext:bar"))) union bar_u bar;
- - The extension writer also writes an aspect production for the host production that they wish to
- - overload, and contribute a pair containing their extension module name and the overload
+ - The extension writer also writes an aspect function for the host dispatch function that they
+ - wish to overload, and contribute a pair containing their extension module name and the overload
  - expression to the list of overloads.  
  -
  - Overloadable constructs include all numeric, logical, assignment and comparison operators, array
  - subscript, function call, member access, assignment to array index, and call to a member access.
  -}
 
-synthesized attribute resolved::Maybe<Expr> occurs on UnaryOp, BinOp, AssignOp, BoolOp, BitOp, CompareOp, NumOp;
+synthesized attribute unaryProd::Maybe<(Expr ::= Expr Location)> occurs on UnaryOp;
+synthesized attribute binaryProd::Maybe<(Expr ::= Expr Expr Location)>
+  occurs on BinOp, AssignOp, BoolOp, BitOp, CompareOp, NumOp;
 
+-- Expressions
+function getArraySubscriptOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+function getMemberCallOverload
+Maybe<(Expr ::= Expr Boolean Name Exprs Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Boolean Name Exprs Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Boolean Name Exprs Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+function getCallOverload
+Maybe<(Expr ::= Expr Exprs Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Exprs Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Exprs Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+function getMemberOverload
+Maybe<(Expr ::= Expr Boolean Name Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Boolean Name Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Boolean Name Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+function getSubscriptAssignOverload
+Maybe<(Expr ::= Expr Expr AssignOp Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Expr AssignOp Expr Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Expr AssignOp Expr Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+function getMemberAssignOverload
+Maybe<(Expr ::= Expr Boolean Name AssignOp Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Boolean Name AssignOp Expr Location)>] with ++;
+  overloads := [];
+  return
+    do (bindMaybe, returnMaybe) {
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Boolean Name AssignOp Expr Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
+    };
+}
+
+-- Unary operators
+function getPreIncOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getPreDecOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getPostIncOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getPostDecOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getAddressOfOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getDereferenceOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getPositiveOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getNegativeOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getBitNegateOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+function getNotOpOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [];
+  return getUnaryOverload(t, env, overloads);
+}
+
+-- Binary operators
+function getEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getMulEqAssignOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getDivEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getModEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getAddEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getSubEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getLshEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getRshEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getAndEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getOrEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getXorEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getAndBoolOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getOrBoolOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getAndBitOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getOrBitOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getXorBitOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getLshBitOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getRshBitOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getEqualsOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getNotEqualsOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getGtOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getLtOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getGteOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getLteOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getAddOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getSubOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getMulOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getDivOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+function getModOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>] with ++;
+  production attribute lOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  production attribute rOverloads::[Pair<String (Expr ::= Expr Expr Location)>] with ++;
+  overloads := [];
+  lOverloads := [];
+  rOverloads := [];
+  
+  return getBinaryOverload(l, r, env, overloads, lOverloads, rOverloads);
+}
+
+-- Helper functions
 function getUnaryOverload
-Maybe<Expr> ::= e::Decorated Expr overloads::[Pair<String (Expr ::= Expr)>]
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env overloads::[Pair<String (Expr ::= Expr Location)>]
 {
   return
     do (bindMaybe, returnMaybe) {
-      n :: String <- moduleName(e.env, e.typerep);
-      prod :: (Expr ::= Expr) <- lookupBy(stringEq, n, overloads);
-      return prod(new(e));
+      n :: String <- moduleName(env, t);
+      prod :: (Expr ::= Expr Location) <- lookupBy(stringEq, n, overloads);
+      return prod;
     };
 }
 
 function getBinaryOverload
-Maybe<Expr> ::=
-  l::Decorated Expr r::Decorated Expr
-  overloads::[Pair<Pair<String String> (Expr ::= Expr Expr)>]
-  lOverloads::[Pair<String (Expr ::= Expr Expr)>]
-  rOverloads::[Pair<String (Expr ::= Expr Expr)>]
+Maybe<(Expr ::= Expr Expr Location)> ::=
+  l::Type r::Type
+  env::Decorated Env
+  overloads::[Pair<Pair<String String> (Expr ::= Expr Expr Location)>]
+  lOverloads::[Pair<String (Expr ::= Expr Expr Location)>]
+  rOverloads::[Pair<String (Expr ::= Expr Expr Location)>]
 {
-  local lModuleName :: Maybe<String> = moduleName(l.env, l.typerep);
-  local rModuleName :: Maybe<String> = moduleName(r.env, r.typerep);
+  local lModuleName :: Maybe<String> = moduleName(env, l);
+  local rModuleName :: Maybe<String> = moduleName(env, r);
 
-  local option1::Maybe<Expr> =
+  local option1::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n1 :: String <- lModuleName;
       n2 :: String <- rModuleName;
-      prod :: (Expr ::= Expr Expr) <- lookupBy(stringPairEq, pair(n1, n2), overloads);
-      return prod(new(l), new(r));
+      prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringPairEq, pair(n1, n2), overloads);
+      return prod;
     };
-  local option2::Maybe<Expr> =
+  local option2::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n :: String <- lModuleName;
-      prod :: (Expr ::= Expr Expr) <- lookupBy(stringEq, n, lOverloads);
-      return prod(new(l), new(r));
+      prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringEq, n, lOverloads);
+      return prod;
     };
-  local option3::Maybe<Expr> =
+  local option3::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n :: String <- rModuleName;
-      prod :: (Expr ::= Expr Expr) <- lookupBy(stringEq, n, rOverloads);
-      return prod(new(l), new(r));
+      prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringEq, n, rOverloads);
+      return prod;
     };
   
   return orElse(option1, orElse(option2, option3));
@@ -93,4 +635,64 @@ function stringPairEq
 Boolean ::= p1::Pair<String String> p2::Pair<String String>
 {
   return p1.fst == p2.fst && p1.snd == p2.snd;
+}
+
+function applyMaybe
+Maybe<a> ::= maybeFn::Maybe<(a ::= b)> a::b
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a))
+    | nothing() -> nothing()
+    end;
+}
+
+function applyMaybe2
+Maybe<a> ::= maybeFn::Maybe<(a ::= b c)> a1::b a2::c
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a1, a2))
+    | nothing() -> nothing()
+    end;
+}
+
+function applyMaybe3
+Maybe<a> ::= maybeFn::Maybe<(a ::= b c d)> a1::b a2::c a3::d
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a1, a2, a3))
+    | nothing() -> nothing()
+    end;
+}
+
+function applyMaybe4
+Maybe<a> ::= maybeFn::Maybe<(a ::= b c d e)> a1::b a2::c a3::d a4::e
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a1, a2, a3, a4))
+    | nothing() -> nothing()
+    end;
+}
+
+function applyMaybe5
+Maybe<a> ::= maybeFn::Maybe<(a ::= b c d e f)> a1::b a2::c a3::d a4::e a5::f
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a1, a2, a3, a4, a5))
+    | nothing() -> nothing()
+    end;
+}
+
+function applyMaybe6
+Maybe<a> ::= maybeFn::Maybe<(a ::= b c d e f g)> a1::b a2::c a3::d a4::e a5::f a6::g
+{
+  return
+    case maybeFn of
+      just(fn) -> just(fn(a1, a2, a3, a4, a5, a6))
+    | nothing() -> nothing()
+    end;
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/overload/OpOverload.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/overload/OpOverload.sv
@@ -608,6 +608,7 @@ Maybe<(Expr ::= Expr Expr Location)> ::=
   local lModuleName :: Maybe<String> = moduleName(env, l);
   local rModuleName :: Maybe<String> = moduleName(env, r);
 
+  -- Option 1: overload for a left extension type and a right extension type
   local option1::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n1 :: String <- lModuleName;
@@ -615,12 +616,14 @@ Maybe<(Expr ::= Expr Expr Location)> ::=
       prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringPairEq, pair(n1, n2), overloads);
       return prod;
     };
+  -- Option 2: overload for a left extension type and any type
   local option2::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n :: String <- lModuleName;
       prod :: (Expr ::= Expr Expr Location) <- lookupBy(stringEq, n, lOverloads);
       return prod;
     };
+  -- Option 2: overload for any type and a right extension type
   local option3::Maybe<(Expr ::= Expr Expr Location)> =
     do (bindMaybe, returnMaybe) {
       n :: String <- rModuleName;
@@ -637,6 +640,7 @@ Boolean ::= p1::Pair<String String> p2::Pair<String String>
   return p1.fst == p2.fst && p1.snd == p2.snd;
 }
 
+-- These helper functions apply maybeFn if it is a just() to the arguments, or otherwise return nothing() 
 function applyMaybe
 Maybe<a> ::= maybeFn::Maybe<(a ::= b)> a::b
 {

--- a/extensions/closure/edu.umn.cs.melt.exts.ableC.closure/abstractsyntax/Apply.sv
+++ b/extensions/closure/edu.umn.cs.melt.exts.ableC.closure/abstractsyntax/Apply.sv
@@ -1,9 +1,9 @@
 grammar edu:umn:cs:melt:exts:ableC:closure:abstractsyntax;
   
-aspect production ovrld:callExpr
-top::Expr ::= f::Expr  a::Exprs
+aspect function ovrld:getCallOverload
+Maybe<(Expr ::= Expr Exprs Location)> ::= t::Type env::Decorated Env
 {
-  overloads <- [pair("edu:umn:cs:melt:exts:ableC:closure:closure", applyExpr(f, a, location=top.location))];
+  overloads <- [pair("edu:umn:cs:melt:exts:ableC:closure:closure", applyExpr(_, _, location=_))];
 }
 
 global applyExprFwrd::Expr = parseExpr(s"""

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/String.sv
@@ -14,99 +14,106 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:overload as ovrld;
 
 global builtin::Location = builtinLoc("string");
 
-aspect production addOp
-top::NumOp ::=
+aspect function ovrld:getAddOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
   lOverloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       \ lhs::Expr rhs::Expr ->
-         appendString(lhs, strExpr(rhs, location=top.location), location=top.location))];
+       \ lhs::Expr rhs::Expr loc::Location ->
+         appendString(lhs, strExpr(rhs, location=loc), location=loc))];
   rOverloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       \ lhs::Expr rhs::Expr ->
-         appendString(strExpr(lhs, location=top.location), rhs, location=top.location))];
+       \ lhs::Expr rhs::Expr loc::Location ->
+         appendString(strExpr(lhs, location=loc), rhs, location=loc))];
 }
 
-aspect production subOp
-top::NumOp ::=
+aspect function ovrld:getSubOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
   lOverloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       \ lhs::Expr rhs::Expr ->
-         removeString(lhs, strExpr(rhs, location=top.location), location=top.location))];
+       \ lhs::Expr rhs::Expr loc::Location ->
+         removeString(lhs, strExpr(rhs, location=loc), location=loc))];
 }
 
-aspect production mulOp
-top::NumOp ::=
+aspect function ovrld:getMulOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
+{
+  lOverloads <- [pair("edu:umn:cs:melt:exts:ableC:string:string", repeatString(_, _, location=_))];
+}
+
+aspect function ovrld:getEqualsOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
   lOverloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       repeatString(_, _, location=top.location))];
-}
-
-aspect production equalsOp
-top::CompareOp ::=
-{
-  lOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:string:string",
-       \ lhs::Expr rhs::Expr ->
-         eqString(lhs, strExpr(rhs, location=top.location), location=top.location))];
+       \ lhs::Expr rhs::Expr loc::Location ->
+         eqString(lhs, strExpr(rhs, location=loc), location=loc))];
   rOverloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       \ lhs::Expr rhs::Expr ->
-         eqString(strExpr(lhs, location=top.location), rhs, location=top.location))];
+       \ lhs::Expr rhs::Expr loc::Location ->
+         eqString(strExpr(lhs, location=loc), rhs, location=loc))];
 }
 
-aspect production eqOp
-top::AssignOp ::=
+aspect function ovrld:getEqOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
-  lOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:string:string",
-       assignString(_, _, location=top.location))];
+  lOverloads <- [pair("edu:umn:cs:melt:exts:ableC:string:string", assignString(_, _, location=_))];
 }
 
-aspect production ovrld:callExpr
-top::Expr ::= f::Expr  a::Exprs
+aspect function ovrld:getMemberCallOverload
+Maybe<(Expr ::= Expr Boolean Name Exprs Location)> ::= t::Type env::Decorated Env
 {
-  memberOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:string:string",
-       memberCallString(_, _, _, a, location=top.location))];
+  overloads <-
+    [pair("edu:umn:cs:melt:exts:ableC:string:string", memberCallString(_, _, _, _, location=_))];
 }
 
-aspect production ovrld:arraySubscriptExpr
-top::Expr ::= lhs::Expr  rhs::Expr
+aspect function ovrld:getArraySubscriptOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= t::Type env::Decorated Env
+{
+  overloads <-
+    [pair("edu:umn:cs:melt:exts:ableC:string:string", subscriptString(_, _, location=_))];
+}
+
+aspect function ovrld:getSubscriptAssignOverload
+Maybe<(Expr ::= Expr Expr AssignOp Expr Location)> ::= t::Type env::Decorated Env
 {
   overloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       subscriptString(lhs, rhs, location=top.location))];
+       \ l::Expr i::Expr op::AssignOp r::Expr loc::Location ->
+         errorExpr([err(loc, "Strings are immutable, cannot assign to index")], location=loc))];
 }
 
-aspect production assignOp
-top::BinOp ::= op::AssignOp
+aspect function ovrld:getMemberAssignOverload
+Maybe<(Expr ::= Expr Boolean Name AssignOp Expr Location)> ::= t::Type env::Decorated Env
 {
-  subscriptOverloads <-
+  overloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:string:string",
-       \ l::Expr i::Expr r::Expr ->
-         errorExpr(
-           [err(top.location, "Strings are immutable, cannot assign to index")],
-           location=top.location))];
-  memberOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:string:string",
-       \ l::Expr d::Boolean m::Name r::Expr ->
-         errorExpr(
-           [err(top.location, s"Cannot assign to field ${m.name} of string")],
-           location=top.location))];
+       \ l::Expr d::Boolean m::Name op::AssignOp r::Expr loc::Location ->
+         errorExpr([err(loc, s"Cannot assign to field ${m.name} of string")], location=loc))];
+}
+
+function getShowOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [pair("edu:umn:cs:melt:exts:ableC:string:string", showString(_, location=_))];
+  return ovrld:getUnaryOverload(t, env, overloads);
+}
+
+function getStrOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
+{
+  production attribute overloads::[Pair<String (Expr ::= Expr Location)>] with ++;
+  overloads := [pair("edu:umn:cs:melt:exts:ableC:string:string", strString(_, location=_))];
+  return ovrld:getUnaryOverload(t, env, overloads);
 }
 
 abstract production showExpr
@@ -114,18 +121,23 @@ top::Expr ::= e::Expr
 {
   propagate substituted;
   top.pp = pp"show(${e.pp})";
-
-  production attribute overloads::[Pair<String Expr>] with ++;
-  overloads :=
-    [pair("edu:umn:cs:melt:exts:ableC:string:string", showString(e, location=top.location))];
   
   local localErrors::[Message] = e.errors;
-  local resolved::Maybe<Expr> =
-    case moduleName(e.env, e.typerep) of
-      just(n) -> lookupBy(stringEq, n, overloads)
-    | nothing() -> nothing()
-    end;
-  local fwrd::Expr = fromMaybe(showHost(e, location=top.location), resolved);
+  local fwrd::Expr =
+    fromMaybe(showHost(_, location=_), getShowOverload(e.typerep, top.env))(e, top.location);
+  
+  forwards to mkErrorCheck(localErrors, fwrd);
+}
+
+abstract production strExpr
+top::Expr ::= e::Expr
+{
+  propagate substituted;
+  top.pp = pp"str(${e.pp})";
+  
+  local localErrors::[Message] = e.errors;
+  local fwrd::Expr =
+    fromMaybe(strHost(_, location=_), getStrOverload(e.typerep, top.env))(e, top.location);
   
   forwards to mkErrorCheck(localErrors, fwrd);
 }
@@ -242,27 +254,6 @@ top::Expr ::= e::Expr
           e,
           nilExpr())),
       location=builtin);
-  forwards to mkErrorCheck(localErrors, fwrd);
-}
-
-abstract production strExpr
-top::Expr ::= e::Expr
-{
-  propagate substituted;
-  top.pp = pp"str(${e.pp})";
-
-  production attribute overloads::[Pair<String Expr>] with ++;
-  overloads :=
-    [pair("edu:umn:cs:melt:exts:ableC:string:string", strString(e, location=top.location))];
-  
-  local localErrors::[Message] = e.errors;
-  local resolved::Maybe<Expr> =
-    case moduleName(e.env, e.typerep) of
-      just(n) -> lookupBy(stringEq, n, overloads)
-    | nothing() -> nothing()
-    end;
-  local fwrd::Expr = fromMaybe(strHost(e, location=top.location), resolved);
-  
   forwards to mkErrorCheck(localErrors, fwrd);
 }
 

--- a/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
+++ b/extensions/string/edu.umn.cs.melt.exts.ableC.string/abstractsyntax/Type.sv
@@ -149,34 +149,22 @@ top::BuiltinType ::= sub::IntegerType
 
 -- Check if errors result from in applying the show() operator to a type 
 function checkShowErrors
-[Message] ::= t::Type env::Decorated Env
+[Message] ::= t::Type env::Decorated Env loc::Location
 {
-  local expr::Expr =
-    showExpr(
-      explicitCastExpr(
-        typeName(directTypeExpr(t), baseTypeExpr()),
-        mkIntConst(0, builtin),
-        location=builtin),
-      location=builtin);
-  expr.env = env;
-  expr.returnType = nothing();
-  
-  return expr.errors;
+  return
+    case orElse(t.showProd, getShowOverload(t, env)) of
+      just(_) -> []
+    | nothing() -> [err(loc, s"show of ${showType(t)} not defined")]
+    end;
 }
 
 -- Check if errors result from in applying the str() operator to a type 
 function checkStrErrors
-[Message] ::= t::Type env::Decorated Env
+[Message] ::= t::Type env::Decorated Env loc::Location
 {
-  local expr::Expr =
-    strExpr(
-      explicitCastExpr(
-        typeName(directTypeExpr(t), baseTypeExpr()),
-        mkIntConst(0, builtin),
-        location=builtin),
-      location=builtin);
-  expr.env = env;
-  expr.returnType = nothing();
-  
-  return expr.errors;
+  return
+    case orElse(t.strProd, getStrOverload(t, env)) of
+      just(_) -> []
+    | nothing() -> [err(loc, s"str of ${showType(t)} not defined")]
+    end;
 }

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
@@ -537,7 +537,7 @@ top::Expr ::= e::Expr
 
   local localErrors::[Message] =
     checkVectorHeaderDef("_show_vector", top.location, top.env) ++
-    checkShowErrors(subType, top.env);
+    checkShowErrors(subType, top.env, top.location);
   local fwrd::Expr =
     callExpr(
       templateDeclRefExpr(

--- a/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
+++ b/extensions/vector/edu.umn.cs.melt.exts.ableC.vector/abstractsyntax/Vector.sv
@@ -16,75 +16,73 @@ imports edu:umn:cs:melt:exts:ableC:string;
 
 global builtin::Location = builtinLoc("vector");
 
-aspect production addOp
-top::NumOp ::=
+aspect function ovrld:getAddOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
   overloads <-
     [pair(
        pair(
          "edu:umn:cs:melt:exts:ableC:vector:vector",
          "edu:umn:cs:melt:exts:ableC:vector:vector"),
-       concatVector(_, _, location=top.location))];
+       concatVector(_, _, location=_))];
 }
 
-aspect production assignOp
-top::BinOp ::= op::AssignOp
+aspect function ovrld:getSubscriptAssignOverload
+Maybe<(Expr ::= Expr Expr AssignOp Expr Location)> ::= t::Type env::Decorated Env
 {
-  subscriptOverloads <-
+  overloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:vector:vector",
-       subscriptAssignVector(_, _, op, _, location=top.location))];
-  memberOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:vector:vector",
-       memberAssignVector(_, _, _, op, _, location=top.location))];
+       subscriptAssignVector(_, _, _, _, location=_))];
 }
 
-aspect production equalsOp
-top::CompareOp ::=
+aspect function ovrld:getMemberAssignOverload
+Maybe<(Expr ::= Expr Boolean Name AssignOp Expr Location)> ::= t::Type env::Decorated Env
+{
+  overloads <-
+    [pair(
+       "edu:umn:cs:melt:exts:ableC:vector:vector",
+       memberAssignVector(_, _, _, _, _, location=_))];
+}
+
+aspect function ovrld:getEqualsOpOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= l::Type r::Type env::Decorated Env
 {
   overloads <-
     [pair(
        pair(
          "edu:umn:cs:melt:exts:ableC:vector:vector",
          "edu:umn:cs:melt:exts:ableC:vector:vector"),
-       eqVector(_, _, location=top.location))];
+       eqVector(_, _, location=_))];
 }
 
-aspect production ovrld:arraySubscriptExpr
-top::Expr ::= lhs::Expr  rhs::Expr
+aspect function ovrld:getArraySubscriptOverload
+Maybe<(Expr ::= Expr Expr Location)> ::= t::Type env::Decorated Env
+{
+  overloads <-
+    [pair("edu:umn:cs:melt:exts:ableC:vector:vector", subscriptVector(_, _, location=_))];
+}
+
+aspect function ovrld:getMemberOverload
+Maybe<(Expr ::= Expr Boolean Name Location)> ::= t::Type env::Decorated Env
+{
+  overloads <-
+    [pair("edu:umn:cs:melt:exts:ableC:vector:vector", memberVector(_, _, _, location=_))];
+}
+
+aspect function ovrld:getMemberCallOverload
+Maybe<(Expr ::= Expr Boolean Name Exprs Location)> ::= t::Type env::Decorated Env
 {
   overloads <-
     [pair(
        "edu:umn:cs:melt:exts:ableC:vector:vector",
-       subscriptVector(lhs, rhs, location=top.location))];
+       memberCallVector(_, _, _, _, location=_))];
 }
 
-aspect production ovrld:memberExpr
-top::Expr ::= lhs::Expr  deref::Boolean  rhs::Name
+aspect function getShowOverload
+Maybe<(Expr ::= Expr Location)> ::= t::Type env::Decorated Env
 {
-  overloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:vector:vector",
-       memberVector(lhs, deref, rhs, location=top.location))];
-}
-
-aspect production ovrld:callExpr
-top::Expr ::= f::Expr  a::Exprs
-{
-  memberOverloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:vector:vector",
-       memberCallVector(_, _, _, a, location=top.location))];
-}
-
-aspect production showExpr
-top::Expr ::= e::Expr
-{
-  overloads <-
-    [pair(
-       "edu:umn:cs:melt:exts:ableC:vector:vector",
-       showVector(e, location=top.location))];
+  overloads <- [pair("edu:umn:cs:melt:exts:ableC:vector:vector", showVector(_, location=_))];
 }
 
 abstract production memberVector


### PR DESCRIPTION
Collection attributes for extensions to contribute new overloads are moved to their own functions.  This allows for an extension performing error checking to explicitly call a function and see if there is an overload for a type, without needing to decorate an AST and look for errors.  The string extension was also refactored in a similar way, eliminating this awful hack that the vector extension performed to for error checking on vector `show`.  

@ericvanwyk @tedinski does this look OK?  Hopefully this will be the last major thing to change with overloading.  