### PR TITLE
Fix flow errors related to substituion

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
@@ -5,3 +5,6 @@ imports silver:langutil:pp;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 
+-- Treat the substitution module like an export for modular analyses,
+-- but make the user import it explicitly 
+option edu:umn:cs:melt:ableC:abstractsyntax:substitution;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
@@ -5,6 +5,6 @@ imports silver:langutil:pp;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 
--- Treat the substitution module like an export for modular analyses,
--- but make the user import it explicitly 
-option edu:umn:cs:melt:ableC:abstractsyntax:substitution;
+-- This module adds a new synthesized attribute that does not depend on the forward,
+-- so it must be exported.  
+exports edu:umn:cs:melt:ableC:abstractsyntax:substitution;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Ast.sv
@@ -5,6 +5,6 @@ imports silver:langutil:pp;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 
--- This module adds a new synthesized attribute that does not depend on the forward,
--- so it must be exported.  
-exports edu:umn:cs:melt:ableC:abstractsyntax:substitution;
+-- Treat the substitution module like an export for modular analyses,
+-- but make the user import it explicitly 
+option edu:umn:cs:melt:ableC:abstractsyntax:substitution;

--- a/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Expr.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Expr.sv
@@ -43,6 +43,11 @@ top::Expr ::= op::UnaryOp  e::Expr
 {
   propagate substituted;
 }
+aspect production qualifiedUnaryOpExpr
+top::Expr ::= op::UnaryOp  e::Expr  collectedTypeQualifiers::Qualifiers
+{
+  propagate substituted;
+}
 aspect production unaryExprOrTypeTraitExpr
 top::Expr ::= op::UnaryTypeOp  e::ExprOrTypeName
 {
@@ -70,6 +75,11 @@ top::Expr ::= lhs::Expr  deref::Boolean  rhs::Name
 }
 aspect production binaryOpExpr
 top::Expr ::= lhs::Expr  op::BinOp  rhs::Expr
+{
+  propagate substituted;
+}
+aspect production qualifiedBinaryOpExpr
+top::Expr ::= lhs::Expr  op::BinOp  rhs::Expr  collectedTypeQualifiers::Qualifiers
 {
   propagate substituted;
 }

--- a/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Substituted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Substituted.sv
@@ -218,3 +218,25 @@ attribute substituted<NoncanonicalType> occurs on NoncanonicalType;
 attribute substituted<BuiltinType> occurs on BuiltinType;
 attribute substituted<RealType> occurs on RealType;
 attribute substituted<IntegerType> occurs on IntegerType;
+
+-- Flowtype declarations for every nonterminal
+flowtype substituted {substitutions} on
+  AsmStatement, AsmArgument, AsmClobbers, AsmOperands, AsmOperand,
+  Attributes, Attribute, Attribs, Attrib, AttribName,
+  Decls, Decl, Declarators, Declarator, FunctionDecl, Parameters, ParameterDecl,
+    StructDecl, UnionDecl, EnumDecl, StructItemList, EnumItemList,
+    StructItem, StructDeclarators, StructDeclarator, EnumItem,
+  Expr, GenericAssocs, GenericAssoc,
+  BinOp, AssignOp, BoolOp, BitOp, CompareOp, NumOp,
+  MemberDesignator,
+  NumericConstant,
+  MaybeExpr, Exprs, ExprOrTypeName,
+  UnaryOp, UnaryTypeOp,
+  MaybeInitializer, Initializer, InitList, Init, Designator,
+  Name, MaybeName,
+  Stmt,
+  TypeName, BaseTypeExpr, TypeModifierExpr, TypeNames,
+  Qualifier, SpecialSpecifier,
+  Type, ArrayType, FunctionType, TagType, NoncanonicalType,
+  BuiltinType, RealType, IntegerType;
+  


### PR DESCRIPTION
This branch fixes a couple of flow errors, and makes the substitution grammar an option.  We may want to make this an export instead, but I am waiting to hear from Ted his thoughts on whether option is appropriate for situations where we don't want to add things to the reference set.  

Copy from our previous email chain (in reverse chronological order):

Looking at this a bit more, it seems that the new flow errors seem to be originating from that 'substitutions' is part of the reference set when the grammar is included as an export, but not when it is included as an option.  
This does seem like a useful behavior, to be able to have 'optional' abstract syntax modules that don't add items to the reference set - the alternative is writing explicit flowtype signatures everywhere, when we may want a different default for a different 'kind' of host grammar.  Could this be a potential reason to keep the substitution grammar as an option?  

Lucas Kramer

On Sat, Jun 10, 2017 at 2:31 PM, Ted Kaminski <tedinski@cs.umn.edu> wrote:
Sounds like somewhere there's a bug in Silver where it's not following options correctly.

I'll try to look soon.

Ted


On Sat, Jun 10, 2017 at 2:29 PM, Lucas Kramer <krame505@umn.edu> wrote:
When I change this to an export, there are a whole bunch of flow errors that show up that aren't there when this is an option.  Can you take a look at this?  See Ast.sv on the fix/substitutionflow branch.  

Lucas Kramer

On Tue, Jun 6, 2017 at 8:01 PM, Lucas Kramer <krame505@umn.edu> wrote:
That is interesting- I wonder why there wasn't a flow error being raised when I didn't import the substitution grammar, if it is exactly the same as exports? Unless I am still misunderstanding. 
I will change this to be an export in the host. 

On Jun 6, 2017 6:49 PM, "Ted Kaminski" <tedinski@cs.umn.edu> wrote:
I neglected to actually answer your question about option. It's exactly like export for everything related to flow analysis. And yeah, conditional exports are meant to work with them.

But this means there's no difference here. Every extension has to deal with substituted no matter what.

Really, the only place where options are actually useful is if there's concrete syntax you want to conditionally export. For attributes and abstract productions, there's no real point in trying to leave them out in an option. The flow analysis still cares about them the same as if they were exported.

Ted

On Jun 6, 2017 6:04 PM, "Lucas Kramer" <krame505@umn.edu> wrote:
Yes, which I thought of doing, but then every extension, including simple examples, need to propagate substituted. But maybe we just need to live with that?

On Jun 6, 2017 1:47 PM, "Ted Kaminski" <tedinski@cs.umn.edu> wrote:
The problem you're trying to solve is that you don't want substituted to depend on the fwd inherited attributes, which extension attributes are required to do, right?

You could just export it from abstractsyntax, too.

Ted

On Mon, Jun 5, 2017 at 8:49 PM, Lucas Kramer <krame505@umn.edu> wrote:
I just wanted to check that my understanding of the semantics of 'option' is correct.  This has no effect on the build (other than compiling the option grammars), unless the optioned grammar is imported explicitly, correct?  
I am thinking that making it an option would be a good fit for fixing our handling of the substitution grammar.  If I understand correctly, this would mean that an extensions could extend the host without importing this grammar, and would pass the flow analysis without needing to propagate substituted on pretty much every forwarding production.  This could be nice for tutorial extensions.  
But when an extension that does import substitution attempts to compose with this extension, there will be flow errors introduced in the extension that lacks the propagate equations for substituted.  Is there any way to specify these missing equations explicitly?  Is this where conditional exports come into play?  I wasn't able to find any documentation for option anywhere, this should really be added to the reference guide.  

So I guess practically, what I am asking, is should we make the substitution grammar an option or an export from the host in ableC?  

Lucas Kramer