### PR TITLE
Fix/mwda special specifiers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ node {
 
       /* env.PATH is the master's path, not the executor's */
       withEnv(["PATH=${params.SILVER_BASE}/support/bin/:${env.PATH}"]) {
-        sh "./build -G ${WORKSPACE}/generated --warn-all"
+        sh "./build -G ${WORKSPACE}/generated --warn-all --warn-error"
       }
     }
 

--- a/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/Decls.sv
@@ -316,20 +316,20 @@ top::Declarator ::= msg::[Message]
 nonterminal FunctionDecl with pp, host<FunctionDecl>, lifted<FunctionDecl>, errors, globalDecls, defs, env, typerep, sourceLocation, returnType, freeVariables;
 
 abstract production functionDecl
-top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
+top::FunctionDecl ::= storage::[StorageClass]  fnquals::SpecialSpecifiers  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
 {
   propagate host, lifted;
   
-  top.pp = ppConcat([terminate(space(), map((.pp), storage)), terminate( space(), specialSpecifiers.pps ),
+  top.pp = ppConcat([terminate(space(), map((.pp), storage)), terminate( space(), fnquals.pps ),
     bty.pp, space(), mty.lpp, name.pp, mty.rpp, ppAttributesRHS(attrs), line(), terminate(cat(semi(), line()), decls.pps),
     text("{"), line(), nestlines(2,body.pp), text("}")]);
 
   -- TODO: consider changing signature of this production to take
   -- SpecialSpecifiers instead of [SpecialSpecifier]
-  local specialSpecifiers :: SpecialSpecifiers =
-     foldr(consSpecialSpecifier, nilSpecialSpecifier(), fnquals);
-  specialSpecifiers.env = top.env;
-  specialSpecifiers.returnType = top.returnType;  
+  --local specialSpecifiers :: SpecialSpecifiers =
+  --   foldr(consSpecialSpecifier, nilSpecialSpecifier(), fnquals);
+  fnquals.env = top.env;
+  fnquals.returnType = top.returnType;  
  
 
   local parameters :: Decorated Parameters =
@@ -342,20 +342,20 @@ top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty:
   local funcDefs::[Def] = bty.defs ++ [valueDef(name.name, functionValueItem(top))];
   local thisFuncDef :: Def = miscDef("this_func", currentFunctionItem(name, top));
   
-  top.errors := bty.errors ++ mty.errors ++ body.errors ++ specialSpecifiers.errors;
+  top.errors := bty.errors ++ mty.errors ++ body.errors ++ fnquals.errors;
   top.globalDecls := bty.globalDecls ++ mty.globalDecls ++ decls.globalDecls ++ 
-                     body.globalDecls ++ specialSpecifiers.globalDecls;
+                     body.globalDecls ++ fnquals.globalDecls;
   top.defs :=
     funcDefs ++
     globalDeclsDefs(mty.globalDecls) ++
     globalDeclsDefs(decls.globalDecls) ++
     globalDeclsDefs(body.globalDecls) ++
-    globalDeclsDefs(specialSpecifiers.globalDecls);
+    globalDeclsDefs(fnquals.globalDecls);
   top.freeVariables =
     bty.freeVariables ++
     removeDefsFromNames([thisFuncDef], mty.freeVariables) ++
     decls.freeVariables ++ --TODO?
-    removeDefsFromNames(top.defs ++ parameters.defs ++ decls.defs ++ body.functiondefs ++ specialSpecifiers.defs, body.freeVariables);
+    removeDefsFromNames(top.defs ++ parameters.defs ++ decls.defs ++ body.functiondefs ++ fnquals.defs, body.freeVariables);
   top.typerep = mty.typerep;
   top.sourceLocation = name.location;
   
@@ -401,7 +401,7 @@ top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty:
 -- Allows extensions to handle nested functions differently
 -- TODO: is this needed?  Should this be forwarding?  
 abstract production nestedFunctionDecl
-top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
+top::FunctionDecl ::= storage::[StorageClass]  fnquals::SpecialSpecifiers  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
 {
   --top.defs := bty.defs ++ [valueDef(name.name, functionValueItem(top))];
   

--- a/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/TypeQualifiers.sv
@@ -109,13 +109,16 @@ top::Qualifier ::=
  - e.g. Function specifiers (inline, _Noreturn)
  -      Alignment specifiers (_Alignas)
  -}
-nonterminal SpecialSpecifier with pp, host<SpecialSpecifier>, lifted<SpecialSpecifier>, env, returnType;
+nonterminal SpecialSpecifier with pp, host<SpecialSpecifier>, lifted<SpecialSpecifier>, env, returnType, errors, globalDecls, defs;
 
 abstract production inlineQualifier
 top::SpecialSpecifier ::=
 {
   propagate host, lifted;
   top.pp = text("inline");
+  top.errors := [];
+  top.globalDecls := [];
+  top.defs := [];
 }
 
 -- C11
@@ -124,6 +127,9 @@ top::SpecialSpecifier ::=
 {
   propagate host, lifted;
   top.pp = text("_Noreturn");
+  top.errors := [];
+  top.globalDecls := [];
+  top.defs := [];
 }
 
 -- C11
@@ -132,8 +138,33 @@ top::SpecialSpecifier ::= e::Expr
 {
   propagate host, lifted;
   top.pp = ppConcat([text("_Alignas"), parens(e.pp)]);
---  top.errors := e.errors;
+  top.errors := e.errors;
+  top.globalDecls := e.globalDecls;
+  top.defs := e.defs;
 }
+
+nonterminal SpecialSpecifiers with pps, host<SpecialSpecifiers>, lifted<SpecialSpecifiers>, env, returnType, errors, globalDecls, defs;
+
+abstract production consSpecialSpecifier
+top::SpecialSpecifiers ::= h::SpecialSpecifier t::SpecialSpecifiers
+{
+  propagate host, lifted;
+  top.pps = h.pp :: t.pps;
+  top.errors := h.errors ++ t.errors;
+  top.globalDecls := h.globalDecls ++ t.globalDecls;
+  top.defs := h.defs ++ t.defs;
+}
+
+abstract production nilSpecialSpecifier
+top::SpecialSpecifiers ::=
+{
+  propagate host, lifted;
+  top.pps = [];
+  top.errors := [];
+  top.globalDecls := [];
+  top.defs := [];
+}
+	
 
 function containsQualifier
 Boolean ::= q::Qualifier t::Type

--- a/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Decls.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Decls.sv
@@ -92,7 +92,7 @@ top::Declarator ::= msg::[Message]
 }
 
 aspect production functionDecl
-top::FunctionDecl ::= storage::[StorageClass]  fnquals::[SpecialSpecifier]  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
+top::FunctionDecl ::= storage::[StorageClass]  fnquals::SpecialSpecifiers  bty::BaseTypeExpr mty::TypeModifierExpr  name::Name  attrs::Attributes  decls::Decls  body::Stmt
 {
   propagate substituted;
 }

--- a/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
@@ -169,9 +169,12 @@ concrete productions top::InitialFunctionDefinition_c
       
       local bt :: ast:BaseTypeExpr =
         ast:figureOutTypeFromSpecifiers(ds.location, ds.typeQualifiers, ds.preTypeSpecifiers, ds.realTypeSpecifiers, ds.mutateTypeSpecifiers);
-      
+
+      local specialSpecifiers :: ast:SpecialSpecifiers =
+        foldr(ast:consSpecialSpecifier, ast:nilSpecialSpecifier(), ds.specialSpecifiers);
+
       top.ast = 
-        ast:functionDecl(ds.storageClass, ds.specialSpecifiers, bt, d.ast, d.declaredIdent, ds.attributes, ast:foldDecl(l.ast), top.givenStmt);
+        ast:functionDecl(ds.storageClass, specialSpecifiers, bt, d.ast, d.declaredIdent, ds.attributes, ast:foldDecl(l.ast), top.givenStmt);
     }
     action {
       -- Function are annoying because we have to open a scope, then add the
@@ -185,7 +188,7 @@ concrete productions top::InitialFunctionDefinition_c
         ast:figureOutTypeFromSpecifiers(d.location, ast:nilQualifier(), [], [], []);
 
       top.ast = 
-        ast:functionDecl([], [], bt, d.ast, d.declaredIdent, ast:nilAttribute(), ast:foldDecl(l.ast), top.givenStmt);
+        ast:functionDecl([], ast:nilSpecialSpecifier(), bt, d.ast, d.declaredIdent, ast:nilAttribute(), ast:foldDecl(l.ast), top.givenStmt);
     }
     action {
       -- Unfortunate duplication. This production is necessary for K&R compatibility

--- a/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
@@ -99,8 +99,11 @@ concrete productions top::InitialNestedFunctionDefinition_c
       local bt :: ast:BaseTypeExpr =
         ast:figureOutTypeFromSpecifiers(ds.location, ds.typeQualifiers, ds.preTypeSpecifiers, ds.realTypeSpecifiers, ds.mutateTypeSpecifiers);
 
+      local specialSpecifiers :: ast:SpecialSpecifiers =
+        foldr(ast:consSpecialSpecifier, ast:nilSpecialSpecifier(), ds.specialSpecifiers);
+
       top.ast =
-        ast:nestedFunctionDecl(ds.storageClass, ds.specialSpecifiers, bt, d.ast, d.declaredIdent, ds.attributes, ast:foldDecl([]), top.givenStmt);
+        ast:nestedFunctionDecl(ds.storageClass, specialSpecifiers, bt, d.ast, d.declaredIdent, ds.attributes, ast:foldDecl([]), top.givenStmt);
     }
     action {
       -- TODO: we have to duplicate this more. yaaay...


### PR DESCRIPTION
This addresses issues #53 and #54 by creating a `SpecialSpecifiers` nonterminal to be used in place of `[SpecialSpecifier]` and adding `--warn-error` in the Jenkinsfile.

Would it be worth changing the signature of `functionDecl` rather than creating a local `specialSpecifiers`? See the TODO comment.

Jenkins seems to have a problem with mkdir on new branches. I've created issue #57 for this.