### PR TITLE
Modifications to allow extension of lexer hack mechanism

### DIFF
--- a/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
@@ -44,10 +44,11 @@ global typenameType :: IdentType = typenameType_c();
 disambiguate Identifier_t, TypeName_t
 {
   pluck
-
     case lookupBy(stringEq, lexeme, head(context)) of
+    | just(lh:identType_c()) -> Identifier_t
     | just(lh:typenameType_c()) -> TypeName_t
-    | _ -> Identifier_t
+    | nothing() -> Identifier_t
+    | it -> error(s"Unexpected lookup result for ${lexeme} in disambiguation function for Identifier_t, TypeName_t: ${hackUnparse(it)}")
     end;
 }
 

--- a/edu.umn.cs.melt.ableC/concretesyntax/lexerHack/LexerHack.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/lexerHack/LexerHack.sv
@@ -2,16 +2,15 @@ grammar edu:umn:cs:melt:ableC:concretesyntax:lexerHack;
 
 imports edu:umn:cs:melt:ableC:abstractsyntax as ast;
 
-nonterminal IdentType;
+-- Nonterminal representing an enumeration of possible identifier types
+-- This is closed to allow extensions to further utilize this mechanism
+closed nonterminal IdentType;
 abstract production identType_c     top::IdentType ::= {}
 abstract production typenameType_c  top::IdentType ::= {}
 
 -- convenient, one single object for each. totally unnecessary of course...
 global identType :: IdentType = identType_c();
 global typenameType :: IdentType = typenameType_c();
-
-
-
 
 
 -- The logic that mutates the 'context' value is distributed amoung the rules


### PR DESCRIPTION
I did a bit of thinking about how we might allow the lexer hack mechanism to be used for disambiguation in extensions, and what consequences this might have with regards to composability, and it was pretty simple to implement so I went ahead and tried.  

Essentially, the only significant change to the host is making `IdentType` a closed nonterminal.  Extensions can now add their own `IdentType`s, and write their own disambiguation functions over corresponding conflicting identifier nonterminals, utilizing the same `context` environment.  

The only significant question I see here is how this relates to composability.  Having two extensions with conflicting identifier terminals could easily lead to new lexer conflicts not covered by any disambiguation functions.  However, in this case, we can simply use transparent prefixes and specifying a preference explicitly to choose one extension over the other.  

I will shortly open a pull request in the template extension that utilizes this.  @tedinski @ericvanwyk @TravisCarlson  - any comments?  