### PR TITLE
Get jenkins green

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/AttributeAnimation.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/AttributeAnimation.sv
@@ -2,6 +2,9 @@
 function animateAttributeOnType
 Type ::= attr::Attributes  ty::Type
 {
+  -- TODO: These are hacks we should probably improve upon.
+  attr.env = emptyEnv();
+  attr.returnType = nothing();
   return
     case attr of
     | consAttribute(gccAttribute(l), t) -> animateAttribOnType(l, animateAttributeOnType(t, ty))
@@ -18,6 +21,9 @@ Type ::= attr::Attributes  ty::Type
 function animateAttribOnType
 Type ::= attr::Attribs  ty::Type
 {
+  -- TODO: These are hacks we should probably improve upon.
+  attr.env = emptyEnv();
+  attr.returnType = nothing();
   return case attr of
   -- Attribs that specify new types (i.e. not type-compatible with what is wrapped)
   -- __vector_size__(num)

--- a/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Attribute.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/substitution/Attribute.sv
@@ -50,9 +50,14 @@ top::Attrib ::= n::AttribName
 aspect production appliedAttrib
 top::Attrib ::= n::AttribName  e::Exprs
 {
+  -- TODO: These are hacks we should probably improve upon.
+  local treat_e_syntactically :: Exprs = e;
+  treat_e_syntactically.env = emptyEnv();
+  treat_e_syntactically.returnType = nothing();
+  
   local substitutions::Substitutions = top.substitutions;
   substitutions.nameIn =
-    case n, e of
+    case n, treat_e_syntactically of
       attribName(n), consExpr(stringLiteral(s), nilExpr()) ->
         if n.name == "refId" then substring(1, length(s) - 1, s) else ""
     | _, _ -> ""


### PR DESCRIPTION
Fixes #70 
Well, sort of. It's a hack, but it's probably a hack that's just fine for now.

Fixes #57 
Apparently `checkout scm` can clean out all non-checked out files. I'm not sure if this is guaranteed behavior or... just what seems to be happening right now. So I've left in code to delete `generated` but otherwise moved its creation to a safe spot in the script. So that should be taken care of.

@krame505 let me know if the first fix is too ugly to merge. But even if it's not ideal, I'd like to merge and just have it get fixed later, if that's okay?