### PR TITLE
Automatically build the correct extension branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node {
     stage ("Extensions") {
       parallel(
         "ableC-skeleton": {
-          echo scm.branches[0].name
+          echo "${scm.branches[0].name}"
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
         },
         "ableC-lib-skeleton": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,8 @@ node {
     }*/
 
     stage ("Extensions") {
-      echo "${scm.branches[0].name}"
+      sh "echo ${scm.branches[0].name}"
+            
       parallel(
         "ableC-skeleton": {
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,9 +66,9 @@ node {
     }*/
 
     stage ("Extensions") {
+      echo "${scm.branches[0].name}"
       parallel(
         "ableC-skeleton": {
-          echo "${scm.branches[0].name}"
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
         },
         "ableC-lib-skeleton": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,13 +66,12 @@ node {
     }*/
 
     stage ("Extensions") {
-      echo "${scm.branches}"
       parallel(
         "ableC-skeleton": {
-          buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
+          buildExtension("/melt-umn/ableC-skeleton", scm)
         },
         "ableC-lib-skeleton": {
-          buildExtension("/melt-umn/ableC-lib-skeleton", scm.branches[0].name)
+          buildExtension("/melt-umn/ableC-lib-skeleton", scm)
         },
         /*
         "ableC-sqlite": {
@@ -197,7 +196,10 @@ node {
   }
 }
 
-def buildExtension(String extension, String branch = 'develop') {
+def buildExtension(String extension, GitSCM scm) {
+    def branch = scm.branches[0].name
+    echo(extension)
+    echo(branch)
     try {
         build job: "$extension/$branch", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,15 +198,14 @@ node {
 
 def buildExtension(String extension, String defaultBranch = 'develop') {
     echo("Called buildExtension")
-    def branch = env.BRANCH_NAME
-    echo(extension)
-    echo(branch)
     try {
+        echo("Trying to build ${extension}/${env.BRANCH_NAME}")
         build job: "${extension}/${env.BRANCH_NAME}", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
     }
     catch (e) {
+        echo("Falling back to build ${extension}/${defaultBranch}")
         build job: "${extension}/${defaultBranch}", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,18 +196,18 @@ node {
   }
 }
 
-def buildExtension(String extension) {
+def buildExtension(String extension, String defaultBranch = 'develop') {
     echo("Called buildExtension")
-    def branch = scm.branches[0].name
+    def branch = env.BRANCH_NAME
     echo(extension)
     echo(branch)
     try {
-        build job: "$extension/$branch", parameters:
+        build job: "${extension}/${env.BRANCH_NAME}", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
     }
     catch (e) {
-        build job: "$extension/develop", parameters:
+        build job: "${extension}/${defaultBranch}", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,14 +56,15 @@ node {
         sh "./build -G generated --warn-all --warn-error"
       }
     }
-    /*
+
+    /* Make sure the tutorials compile before bothering to build all the other extensions */
     stage ("Tutorials") {
       dir("tutorials") {
         withEnv(["PATH=${params.SILVER_BASE}/support/bin/:${env.PATH}"]) {
           sh "./build-all"
         }
       }
-    }*/
+    }
 
     stage ("Extensions") {
       parallel(
@@ -73,95 +74,51 @@ node {
         "ableC-lib-skeleton": {
           buildExtension("/melt-umn/ableC-lib-skeleton")
         },
-        /*
         "ableC-sqlite": {
-//          build job: '/melt-umn/ableC-sqlite/develop', parameters:
-          build job: "/melt-umn/ableC-sqlite/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-sqlite")
         },
         "ableC-condition-tables": {
-//          build job: '/melt-umn/ableC-condition-tables/develop', parameters:
-          build job: "/melt-umn/ableC-condition-tables/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-ableC-condition-tables")
         },
         "ableC-interval": {
-//          build job: '/melt-umn/ableC-interval/develop', parameters:
-          build job: "/melt-umn/ableC-interval/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-interval")
         },
         "ableC-cilk": {
-//          build job: '/melt-umn/ableC-cilk/develop', parameters:
-          build job: "/melt-umn/ableC-cilk/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-cilk")
         },
         "ableC-halide": {
-//          build job: '/melt-umn/ableC-halide/develop', parameters:
-          build job: "/melt-umn/ableC-halide/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-halide")
         },
         "ableC-closure": {
-//          build job: '/melt-umn/ableC-closure/develop', parameters:
-          build job: "/melt-umn/ableC-closure/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-closure")
         },
         "ableC-templating": {
-//          build job: '/melt-umn/ableC-templating/develop', parameters:
-          build job: "/melt-umn/ableC-templating/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-templating")
         },
         "ableC-string": {
-//          build job: '/melt-umn/ableC-string/develop', parameters:
-          build job: '/melt-umn/ableC-string/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-string")
         },
         "ableC-vector": {
-//          build job: '/melt-umn/ableC-vector/develop', parameters:
-          build job: '/melt-umn/ableC-vector/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-vector")
         },
         "ableC-algebraic-data-types": {
-//          build job: '/melt-umn/ableC-algebraic-data-types/develop', parameters:
-          build job: '/melt-umn/ableC-algebraic-data-types/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
-        },
-        "ableC_sample_projects": {
-//          build job: '/melt-umn/ableC_sample_projects/master', parameters:
-          build job: '/melt-umn/ableC_sample_projects/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-algebraic-data-types")
         },
         "ableC-nonnull": {
-//          build job: '/melt-umn/ableC-nonnull/develop', parameters:
-          build job: '/melt-umn/ableC-nonnull/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-nonnull")
         },
         "ableC-checkBounds": {
-//          build job: '/melt-umn/ableC-checkBounds/develop', parameters:
-          build job: '/melt-umn/ableC-checkBounds/feature%2Ftype_qualifiers', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-checkBounds")
         },
         "ableC-watch": {
-          build job: '/melt-umn/ableC-watch/develop', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-watch")
         },
         "ableC-dimensionalAnalysis": {
-          build job: '/melt-umn/ableC-dimensionalAnalysis/develop', parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
-        }*/
+          buildExtension("/melt-umn/ableC-dimensionalAnalysis")
+        }
+        "ableC_sample_projects": {
+          buildExtension("/melt-umn/ableC_sample_projects", "master")
+        },
       )
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,8 +66,7 @@ node {
     }*/
 
     stage ("Extensions") {
-      echo "test"
-            
+      echo "${scm.branches}"
       parallel(
         "ableC-skeleton": {
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ node {
     }*/
 
     stage ("Extensions") {
-      sh "echo ${scm.branches[0].name}"
+      echo "test"
             
       parallel(
         "ableC-skeleton": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,7 @@ node {
     stage ("Extensions") {
       parallel(
         "ableC-skeleton": {
+          println scm.branches[0].name
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
         },
         "ableC-lib-skeleton": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,6 +197,7 @@ node {
 }
 
 def buildExtension(String extension) {
+    echo("Called buildExtension")
     def branch = scm.branches[0].name
     echo(extension)
     echo(branch)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,7 @@ node {
     stage ("Extensions") {
       parallel(
         "ableC-skeleton": {
-          println scm.branches[0].name
+          echo scm.branches[0].name
           buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
         },
         "ableC-lib-skeleton": {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,10 +68,10 @@ node {
     stage ("Extensions") {
       parallel(
         "ableC-skeleton": {
-          buildExtension("/melt-umn/ableC-skeleton", scm)
+          buildExtension("/melt-umn/ableC-skeleton")
         },
         "ableC-lib-skeleton": {
-          buildExtension("/melt-umn/ableC-lib-skeleton", scm)
+          buildExtension("/melt-umn/ableC-lib-skeleton")
         },
         /*
         "ableC-sqlite": {
@@ -196,7 +196,7 @@ node {
   }
 }
 
-def buildExtension(String extension, GitSCM scm) {
+def buildExtension(String extension) {
     def branch = scm.branches[0].name
     echo(extension)
     echo(branch)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,14 +56,14 @@ node {
         sh "./build -G generated --warn-all --warn-error"
       }
     }
-    
+    /*
     stage ("Tutorials") {
       dir("tutorials") {
         withEnv(["PATH=${params.SILVER_BASE}/support/bin/:${env.PATH}"]) {
           sh "./build-all"
         }
       }
-    }
+    }*/
 
     stage ("Extensions") {
       parallel(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,10 +115,10 @@ node {
         },
         "ableC-dimensionalAnalysis": {
           buildExtension("/melt-umn/ableC-dimensionalAnalysis")
-        }
+        },
         "ableC_sample_projects": {
           buildExtension("/melt-umn/ableC_sample_projects", "master")
-        },
+        }
       )
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,17 +68,12 @@ node {
     stage ("Extensions") {
       parallel(
         "ableC-skeleton": {
-//          build job: '/melt-umn/ableC-skeleton/develop', parameters:
-          build job: "/melt-umn/ableC-skeleton/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-skeleton", scm.branches[0].name)
         },
         "ableC-lib-skeleton": {
-//          build job: '/melt-umn/ableC-lib-skeleton/develop', parameters:
-          build job: "/melt-umn/ableC-lib-skeleton/feature%2Ftype_qualifiers", parameters:
-            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
-             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+          buildExtension("/melt-umn/ableC-lib-skeleton", scm.branches[0].name)
         },
+        /*
         "ableC-sqlite": {
 //          build job: '/melt-umn/ableC-sqlite/develop', parameters:
           build job: "/melt-umn/ableC-sqlite/feature%2Ftype_qualifiers", parameters:
@@ -166,7 +161,7 @@ node {
           build job: '/melt-umn/ableC-dimensionalAnalysis/develop', parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
-        }
+        }*/
       )
     }
 
@@ -199,6 +194,19 @@ node {
       notifyBuild('BACK_TO_NORMAL')
     }
   }
+}
+
+def buildExtension(String extension, String branch = 'develop') {
+    try {
+        build job: "$extension/$branch", parameters:
+            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
+             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+    }
+    catch (e) {
+        build job: "$extension/develop", parameters:
+            [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
+             [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
+    }
 }
 
 /* Slack / email notification

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -199,8 +199,8 @@ node {
 def buildExtension(String extension, String defaultBranch = 'develop') {
     echo("Called buildExtension")
     try {
-        echo("Trying to build ${extension}/${env.BRANCH_NAME}")
-        build job: "${extension}/${env.BRANCH_NAME}", parameters:
+        echo("Trying to build ${extension}/${env.JOB_BASE_NAME}")
+        build job: "${extension}/${env.JOB_BASE_NAME}", parameters:
             [[$class: 'StringParameterValue', name: 'SILVER_BASE', value: params.SILVER_BASE],
              [$class: 'StringParameterValue', name: 'ABLEC_BASE', value: WORKSPACE]]
     }


### PR DESCRIPTION
This now attempts to build an extension branch with the same name as the ableC branch, and if that fails it falls back to building whatever default is specified.  
Note that this was branched off of feature/type_qualifiers, so I am pulling against that branch instead of develop, and will merge before #82 is merged.  
I'm going to go ahead and merge this once Jenkins passes.  