### PR TITLE
Fix bug with line numbers when whitespace follows cpp tags

### DIFF
--- a/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
@@ -28,7 +28,7 @@ terminal Hash_t '#';
 
 
 -- I give up!
-ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\n\r]+)/
+ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\n]?[\r]?)/
   action {
     filename = 
       substring(

--- a/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
+++ b/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
@@ -28,7 +28,7 @@ terminal Hash_t '#';
 
 
 -- I give up!
-ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\n]?[\r]?)/
+ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\r]?[\n]?)/
   action {
     filename = 
       substring(


### PR DESCRIPTION
Fixes #51, finally.

The issue was that the cpp tag regex ends with matching an arbitrary number of newlines, which ends up matching the blank lines immediately following a header include - which are then ignored because the line number is reset *after* these are seen by copper.  