### PR TITLE
Fix global decl lifting bug

### DIFF
--- a/edu.umn.cs.melt.ableC/abstractsyntax/host/Lifted.sv
+++ b/edu.umn.cs.melt.ableC/abstractsyntax/host/Lifted.sv
@@ -214,9 +214,8 @@ aspect production consGlobalDecl
 top::GlobalDecls ::= h::Decl  t::GlobalDecls
 {
   propagate host;
-  
-  local newDecls::Decls = foldDecl(map(\ d::Decorated Decl -> d.lifted, h.globalDecls));
-  top.lifted = consGlobalDecl(decls(newDecls), consGlobalDecl(h.lifted, t.lifted));
+  top.lifted =
+    foldr(consGlobalDecl, t.lifted, map(\ d::Decorated Decl -> d.lifted, h.unfoldedGlobalDecls));
 }
 
 -- Utility functions


### PR DESCRIPTION
Very small but important fix: Previously we were only inserting lifted declarations at the level of `GlobalDecls`.  This has a slight problem: If an extension forwards to, e.g `decls(consDecl(a, consDecl(b, nilDecl()))`, and `b` wants to lift something, it gets inserted before `a` which is a problem if the thing being lifted references something defined by `a`.  This was a fun one to track down...

Instead, we can reuse the `unfoldedGlobalDecls` attribute that translates a `Decls` nonterminal into a list of `Decorated Decl`s, including their respective `globalDecls` before each.  