### PR TITLE
Add env items in function decls for standard-ish builtin identifiers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ finally {
 } // node
 
 // Build extension (from /melt-umn/${repo}/develop OR current branch, if it exists
-def task_extension(extension_name, String ABLEC_BASE, String ABLEC_GEN) {
+def task_extension(String extension_name, String ABLEC_BASE, String ABLEC_GEN) {
   return {
     // Try to build a branch with the same name, otherwise fallback to develop
     def jobname = "/melt-umn/${extension_name}/${hudson.Util.rawEncode(env.BRANCH_NAME)}"

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Debug.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Debug.sv
@@ -17,6 +17,10 @@ aspect production functionValueItem
 top::ValueItem ::= s::Decorated FunctionDecl
 { top.pp = text("FunctionDecl"); } --s.pp; }
 
+aspect production builtinValueItem
+top::ValueItem ::= t::Type
+{ top.pp = text("BuiltinValueItem"); }
+
 aspect production builtinFunctionValueItem
 top::ValueItem ::= t::Type  handler::(Expr ::= Name Exprs Location)
 { top.pp = text("BuiltinFunctionValueItem"); }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
@@ -37,6 +37,14 @@ top::ValueItem ::= s::Decorated FunctionDecl
   top.isItemValue = true;
 }
 
+abstract production builtinValueItem
+top::ValueItem ::= t::Type
+{
+  top.typerep = t;
+  top.sourceLocation = loc("<builtin>", 1, 0, 1, 0, 0, 1);
+  top.isItemValue = true;
+}
+
 abstract production builtinFunctionValueItem
 top::ValueItem ::= t::Type  handler::(Expr ::= Name Exprs Location)
 {

--- a/testing/expected-results/negative
+++ b/testing/expected-results/negative
@@ -44,7 +44,7 @@ Negative test       - FAIL: NO ERROR    tests/kframework/negative/j022a.c
 Negative test       - PASS:             tests/kframework/negative/j026a.c
 Negative test       - PASS:             tests/kframework/negative/j027a.c
 Negative test       - FAIL: NO ERROR    tests/kframework/negative/j027b.c
-Negative test       - FAIL: NO ERROR    tests/kframework/negative/j032a.c
+Negative test       - PASS:             tests/kframework/negative/j032a.c
 Negative test       - FAIL: NO ERROR    tests/kframework/negative/j032b.c
 Negative test       - FAIL: NO ERROR    tests/kframework/negative/j033a.c
 Negative test       - PASS:             tests/kframework/negative/j033b.c
@@ -246,7 +246,6 @@ Failures:
                         tests/kframework/negative/j021f.c
                         tests/kframework/negative/j022a.c
                         tests/kframework/negative/j027b.c
-                        tests/kframework/negative/j032a.c
                         tests/kframework/negative/j032b.c
                         tests/kframework/negative/j033a.c
                         tests/kframework/negative/j033c.c
@@ -364,10 +363,10 @@ Pass: 0
 Fail: 0
 
 Negative tests:
-Pass: 55
-Fail: 151
+Pass: 56
+Fail: 150
 
 Summary:
-Pass: 55
-Fail: 151
+Pass: 56
+Fail: 150
 

--- a/testing/expected-results/positive
+++ b/testing/expected-results/positive
@@ -186,8 +186,8 @@ Positive test       - PASS:             tests/kframework/positive/j022a.c
 Positive test       - PASS:             tests/kframework/positive/j026a.c
 Positive test       - PASS:             tests/kframework/positive/j027a.c
 Positive test       - PASS:             tests/kframework/positive/j027b.c
-Positive test       - FAIL: ERROR       tests/kframework/positive/j032a.c
-Positive test       - FAIL: ERROR       tests/kframework/positive/j032b.c
+Positive test       - PASS:             tests/kframework/positive/j032a.c
+Positive test       - PASS:             tests/kframework/positive/j032b.c
 Positive test       - PASS:             tests/kframework/positive/j033a.c
 Positive test       - FAIL: ERROR       tests/kframework/positive/j033b.c
 Positive test       - PASS:             tests/kframework/positive/j033c.c
@@ -345,21 +345,19 @@ Failures:
                         tests/headers/positive/x86intrin.c
                         tests/headers/positive/xmmintrin.c
                         tests/kframework/positive/j020b.c
-                        tests/kframework/positive/j032a.c
-                        tests/kframework/positive/j032b.c
                         tests/kframework/positive/j033b.c
                         tests/kframework/positive/j049c.c
                         tests/kframework/positive/j079h.c
 
 Positive tests:
-Pass: 305
-Fail: 22
+Pass: 307
+Fail: 20
 
 Negative tests:
 Pass: 0
 Fail: 0
 
 Summary:
-Pass: 305
-Fail: 22
+Pass: 307
+Fail: 20
 


### PR DESCRIPTION
For now, just the `const char *` values  `__func__`, `__FUNCTION__`, and `__PRETTY_FUNCTION__`, all available within functions in GCC.  Needed in order to get programs using `assert()` from `<assert.h>` to compile.  