### PR TITLE
Some fixes related to arrays

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -70,7 +70,7 @@ top::Expr ::= id::Name
   top.globalDecls := [];
   top.defs := [];
   top.typerep = id.valueItem.typerep;
-  top.freeVariables = [id];
+  top.freeVariables = top.typerep.freeVariables ++ [id];
   top.isLValue = true;
   
   top.errors <- id.valueLookupCheck;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -2,17 +2,18 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
 import edu:umn:cs:melt:ableC:abstractsyntax:overloadable as ovrld;
 
-nonterminal Expr with location, pp, host<Expr>, lifted<Expr>, globalDecls, errors, defs, env, returnType, freeVariables, typerep, isLValue;
+nonterminal Expr with location, pp, host<Expr>, lifted<Expr>, globalDecls, errors, defs, env, returnType, freeVariables, typerep, isLValue, integerConstantValue;
 
-flowtype Expr = decorate {env, returnType}, isLValue {decorate};
+flowtype Expr = decorate {env, returnType}, isLValue {decorate}, integerConstantValue {decorate};
 
-synthesized attribute integerConstantValue :: Maybe<Integer>; -- TODO: Is this actually used for anything
 synthesized attribute isLValue::Boolean;
+synthesized attribute integerConstantValue::Maybe<Integer>;
 
 aspect default production
 top::Expr ::=
 {
   top.isLValue = false;
+  top.integerConstantValue = nothing();
 }
 
 abstract production errorExpr

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprConstants.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprConstants.sv
@@ -15,6 +15,7 @@ top::Expr ::= c::NumericConstant
   top.freeVariables = [];
   top.typerep = builtinType(nilQualifier(), c.constanttyperep);
   top.isLValue = false;
+  top.integerConstantValue = c.integerConstantValue;
 }
 abstract production imaginaryConstant
 top::Expr ::= c::NumericConstant
@@ -45,8 +46,8 @@ top::Expr ::= num::String  c::CharPrefix
   top.isLValue = false;
 }
 
-nonterminal NumericConstant with location, pp, host<NumericConstant>, lifted<NumericConstant>, errors, env, constanttyperep;
-flowtype NumericConstant = decorate {env}, constanttyperep {decorate};
+nonterminal NumericConstant with location, pp, host<NumericConstant>, lifted<NumericConstant>, errors, env, constanttyperep, integerConstantValue;
+flowtype NumericConstant = decorate {env}, constanttyperep {decorate}, integerConstantValue {decorate};
 
 synthesized attribute constanttyperep :: BuiltinType;
 
@@ -57,6 +58,7 @@ top::NumericConstant ::= num::String  unsigned::Boolean  suffix::IntSuffix
   top.pp = text(num);
   top.errors := [];
   top.constanttyperep = if unsigned then unsignedType(suffix.constinttyperep) else signedType(suffix.constinttyperep);
+  top.integerConstantValue = just(toInt(num));
 }
 abstract production hexIntegerConstant
 top::NumericConstant ::= num::String  unsigned::Boolean  suffix::IntSuffix
@@ -65,6 +67,7 @@ top::NumericConstant ::= num::String  unsigned::Boolean  suffix::IntSuffix
   top.pp = text(num);
   top.errors := [];
   top.constanttyperep = if unsigned then unsignedType(suffix.constinttyperep) else signedType(suffix.constinttyperep);
+  top.integerConstantValue = nothing(); -- TODO
 }
 abstract production octIntegerConstant
 top::NumericConstant ::= num::String  unsigned::Boolean  suffix::IntSuffix
@@ -73,6 +76,7 @@ top::NumericConstant ::= num::String  unsigned::Boolean  suffix::IntSuffix
   top.pp = text(num);
   top.errors := [];
   top.constanttyperep = if unsigned then unsignedType(suffix.constinttyperep) else signedType(suffix.constinttyperep);
+  top.integerConstantValue = nothing(); -- TODO
 }
 
 abstract production floatConstant
@@ -82,6 +86,7 @@ top::NumericConstant ::= num::String  suffix::FloatSuffix
   top.pp = text(num);
   top.errors := [];
   top.constanttyperep = realType(suffix.constfloattyperep);
+  top.integerConstantValue = nothing();
 }
 abstract production hexFloatConstant
 top::NumericConstant ::= num::String  suffix::FloatSuffix
@@ -90,6 +95,7 @@ top::NumericConstant ::= num::String  suffix::FloatSuffix
   top.pp = text(num);
   top.errors := [];
   top.constanttyperep = realType(suffix.constfloattyperep);
+  top.integerConstantValue = nothing();
 }
 
 nonterminal IntSuffix with constinttyperep; -- nothing, L, LL

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/FreeVariables.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/FreeVariables.sv
@@ -9,6 +9,7 @@ flowtype freeVariables {decorate} on
   AsmStatement, AsmArgument, AsmOperands, AsmOperand,
   Expr, GenericAssocs, GenericAssoc,
   TypeName, BaseTypeExpr, TypeModifierExpr, TypeNames,
+  Type, ArrayType, FunctionType,
   MaybeExpr, Exprs, ExprOrTypeName,
   Stmt,
   MaybeInitializer, Initializer, InitList, Init, Designator;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
@@ -446,9 +446,13 @@ top::TypeModifierExpr ::= element::TypeModifierExpr  indexQualifiers::Qualifiers
     size.pp
     ])), element.rpp);
 
-  top.typerep = arrayType(element.typerep, indexQualifiers, sizeModifier,
-    -- TODO: this is a lie: we're not checking if it's constant sized!
-    variableArrayType(size));
+  top.typerep =
+    arrayType(
+      element.typerep, indexQualifiers, sizeModifier,
+      case size.integerConstantValue of
+        just(v) -> constantArrayType(v)
+      | nothing() -> variableArrayType(size)
+      end);
   top.errors := element.errors ++ size.errors;
   top.globalDecls := element.globalDecls ++ size.globalDecls;
   top.freeVariables = element.freeVariables ++ size.freeVariables;

--- a/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
+++ b/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
@@ -68,7 +68,7 @@ IOVal<Integer> ::= args::[String] ioIn::IO
   local xcArgs :: [String] = partitionedArgs.fst;
   
   local cppOptions :: String = if length(args) >= 2 then implode(" ", cppArgs) else "" ;
-  local cppCmd :: String = "gcc -E -x c -D _GNU_SOURCE -std=gnu1x -I . " ++ cppOptions;
+  local cppCmd :: String = "gcc -E -x c -D _POSIX_C_SOURCE -std=gnu1x -I . " ++ cppOptions;
   local fullCppCmd :: String = cppCmd ++ " \"" ++ fileName ++ "\" > " ++ cppFileName;
   
   local result::IOMonad<Integer> = do (bindIO, returnIO) {

--- a/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
+++ b/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
@@ -68,7 +68,7 @@ IOVal<Integer> ::= args::[String] ioIn::IO
   local xcArgs :: [String] = partitionedArgs.fst;
   
   local cppOptions :: String = if length(args) >= 2 then implode(" ", cppArgs) else "" ;
-  local cppCmd :: String = "gcc -E -x c -D _POSIX_C_SOURCE -std=gnu1x -I . " ++ cppOptions;
+  local cppCmd :: String = "gcc -E -x c -D _GNU_SOURCE -std=gnu1x -I . " ++ cppOptions;
   local fullCppCmd :: String = cppCmd ++ " \"" ++ fileName ++ "\" > " ++ cppFileName;
   
   local result::IOMonad<Integer> = do (bindIO, returnIO) {


### PR DESCRIPTION
I fixed a few issues related to arrays that I found while adding support for to capturing variable-length arrays in the closure extension: 
* Implement proper typing for `arrayTypeExprWithExpr`.  Previously, we were treating all `arrayTypeExprWithExpr`s as having `variableArrayType`.  I implemented `integerConstantValue` on `Expr`, to detect when an expression is just an integer constant, properly handling the case where an array has `constantArrayType`.  This currently does discard suffixes and breaks if the given constant is larger than a Silver `Integer`.  Also `char` constants are also technically allowed to be array sizes... but I'm not implementing that right now.  
* Dynamic array sizes mean that translating a `Type` can yield something with free variables, unfortunately.  When a var is referenced, also include any free variables in its `Type`.  
* Properly handle parentheses for array and function pointers.  When we see one of these in the wild, we have been correctly parsing it as `pointerType(parenType(arrayType(...)))`.  But an extension can directly forward to `pointerType(arrayType(...))`, which we need to notice and add the intervening parens explicitly.  