### PR TITLE
Add a way of accessing all but the global env scope

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Env.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Env.sv
@@ -83,6 +83,11 @@ Decorated Env ::= e::Decorated Env
 {
   return decorate globalEnv_i(e) with {};
 }
+function nonGlobalEnv
+Decorated Env ::= e::Decorated Env
+{
+  return decorate nonGlobalEnv_i(e) with {};
+}
 
 -- Environment lookup functions
 

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/EnvPlumbing.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/EnvPlumbing.sv
@@ -66,6 +66,15 @@ top::Env ::= e::Decorated Env
   top.refIds = globalScope(e.refIds);
   top.misc = globalScope(e.misc);
 }
+abstract production nonGlobalEnv_i
+top::Env ::= e::Decorated Env
+{
+  top.labels = nonGlobalScope(e.labels);
+  top.tags = nonGlobalScope(e.tags);
+  top.values = nonGlobalScope(e.values);
+  top.refIds = nonGlobalScope(e.refIds);
+  top.misc = nonGlobalScope(e.misc);
+}
 
 {- Definition list productions provide a way of folding up defs into Contribs lists
  -}

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Scope.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/Scope.sv
@@ -44,11 +44,17 @@ Scopes<a> ::= s::Scopes<a>
 {
   return tm:empty(compareString) :: s;
 }
-{-- Create a new innermost scope -}
+{-- Get the outermost scope -}
 function globalScope
 Scopes<a> ::= s::Scopes<a>
 {
   return [last(s)];
+}
+{-- Get all but the outermost scope -}
+function nonGlobalScope
+Scopes<a> ::= s::Scopes<a>
+{
+  return init(s);
 }
 {-- Looks up an identifier in the closest scope that has a match -}
 function lookupScope

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
@@ -9,7 +9,7 @@ abstract production nullStmt
 top::Stmt ::=
 {
   propagate host, lifted;
-  top.pp = notext();
+  top.pp = semi();
   top.errors := [];
   top.globalDecls := [];
   top.defs := [];

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -467,7 +467,8 @@ top::TagType ::= kwd::StructOrEnumOrUnion  name::String  refId::String
 {
   propagate host;
   top.pp = ppConcat([kwd.pp, space(), text(name)]);
-  top.mangledName = s"${kwd.mangledName}_${name}_${substitute(":", "_", refId)}";
+  top.mangledName =
+    s"${kwd.mangledName}_${if name == "<anon>" then "anon" else name}_${substitute(":", "_", refId)}";
   top.isIntegerType = false;
 }
 

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -616,6 +616,8 @@ top::Type ::= sub::NoncanonicalType
   top.rpp = sub.rpp;
   top.baseTypeExpr = sub.baseTypeExpr;
   top.typeModifierExpr = sub.typeModifierExpr;
+  top.withTypeQualifiers = sub.withTypeQualifiers;
+  sub.addedTypeQualifiers = top.addedTypeQualifiers;
 
   -- behavior? maybe it should be pushed down? TODO
   --top.mangledName = ;
@@ -628,8 +630,8 @@ top::Type ::= sub::NoncanonicalType
 }
 
 {-- Types that resolve to other types. -}
-nonterminal NoncanonicalType with canonicalType, lpp, rpp, host<NoncanonicalType>, baseTypeExpr, typeModifierExpr;
-flowtype NoncanonicalType = decorate {}, canonicalType {}, baseTypeExpr {}, typeModifierExpr {};
+nonterminal NoncanonicalType with canonicalType, lpp, rpp, host<NoncanonicalType>, baseTypeExpr, typeModifierExpr, withTypeQualifiers, addedTypeQualifiers;
+flowtype NoncanonicalType = decorate {}, canonicalType {}, baseTypeExpr {}, typeModifierExpr {}, withTypeQualifiers {addedTypeQualifiers};
 
 synthesized attribute canonicalType :: Type;
 
@@ -644,6 +646,8 @@ top::NoncanonicalType ::= resolved::Type
   top.rpp = resolved.rpp;
   top.baseTypeExpr = resolved.baseTypeExpr;
   top.typeModifierExpr = resolved.typeModifierExpr;
+  top.withTypeQualifiers = resolved.withTypeQualifiers;
+  resolved.addedTypeQualifiers = top.addedTypeQualifiers;
 
   top.canonicalType = resolved;
 }
@@ -669,6 +673,8 @@ top::NoncanonicalType ::= wrapped::Type
   top.rpp = cat( text(")"), wrapped.rpp );
   top.baseTypeExpr = wrapped.baseTypeExpr;
   top.typeModifierExpr = parenTypeExpr(wrapped.typeModifierExpr);
+  top.withTypeQualifiers = wrapped.withTypeQualifiers;
+  wrapped.addedTypeQualifiers = top.addedTypeQualifiers;
 
   top.canonicalType = wrapped;
 }
@@ -697,6 +703,8 @@ top::NoncanonicalType ::= original::Type  pointer::Type
   top.rpp = original.rpp;
   top.baseTypeExpr = original.baseTypeExpr;
   top.typeModifierExpr = original.typeModifierExpr;
+  top.withTypeQualifiers = pointer.withTypeQualifiers;
+  pointer.addedTypeQualifiers = top.addedTypeQualifiers;
 
   top.canonicalType = pointer;
 }
@@ -718,6 +726,9 @@ top::NoncanonicalType ::= q::Qualifiers  n::String  resolved::Type
   top.rpp = notext();
   top.baseTypeExpr = typedefTypeExpr(q, name(n, location=builtinLoc("host")));
   top.typeModifierExpr = baseTypeExpr();
+  top.withTypeQualifiers =
+    noncanonicalType(
+      typedefType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), n, resolved));
 
   top.canonicalType = resolved;
 }
@@ -733,6 +744,9 @@ top::NoncanonicalType ::= q::Qualifiers  resolved::Type
   top.baseTypeExpr =
     typeofTypeExpr(q, typeNameExpr(typeName(resolved.baseTypeExpr, resolved.typeModifierExpr)));
   top.typeModifierExpr = baseTypeExpr();
+  top.withTypeQualifiers =
+    noncanonicalType(
+      typeofType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), resolved));
 }
 
 function filterExtensionQualifiers

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
@@ -7,7 +7,7 @@ imports edu:umn:cs:melt:ableC:abstractsyntax:host as ast;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction as ast;
 imports silver:langutil;
 
-terminal CPP_Extension_t '__extension__' lexer classes {Ckeyword};
+terminal CPP_Extension_t '__extension__' lexer classes {Ckeyword}, precedence=0;
 terminal CPP_Inline_OneSided_t '__inline' lexer classes {Ckeyword};
 terminal CPP_Inline_t '__inline__' lexer classes {Ckeyword};
 terminal CPP_Signed_t '__signed__' lexer classes {Ckeyword};


### PR DESCRIPTION
Needed to fix a bug in the closure extension.  