### PR TITLE
Fix Jenkins downstream integration builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ melt.trynode('ableC') {
     }
   }
 
-  stage ("Test") {
+  /*stage ("Test") {
     dir("testing/expected-results") {
       withEnv(newenv) {
         sh "./runTests"
@@ -34,7 +34,7 @@ melt.trynode('ableC') {
         sh "./build-all"
       }
     }
-  }
+  }*/
 
   stage ("Integration") {
     // All known, stable extensions to build downstream
@@ -62,12 +62,14 @@ melt.trynode('ableC') {
 
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
-    tasks << extensions.collectEntries { t ->
+    tasks << (extensions.collectEntries { t ->
       [t: { melt.buildProject("/melt-umn/${t}", newargs) }]
-    }
-    tasks << specific_jobs.collectEntries { t ->
+    })
+    tasks << (specific_jobs.collectEntries { t ->
       [t: { melt.buildJob(t, newargs) }]
-    }
+    })
+
+    print tasks
     
     parallel tasks
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,12 +62,12 @@ melt.trynode('ableC') {
 
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
-    tasks << (extensions.collectEntries { t ->
+    tasks << extensions.collectEntries { t ->
       [t: { melt.buildProject("/melt-umn/${t}", newargs) }]
-    })
-    tasks << (specific_jobs.collectEntries { t ->
-      [t: { melt.buildJob(t, newargs) }]
-    })
+    }
+    /*tasks << specific_jobs.collectEntries { t ->
+      [(t): { melt.buildJob(t, newargs) }]
+    }*/
 
     print tasks
     

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ melt.trynode('ableC') {
     }
   }
 
-  /*stage ("Test") {
+  stage ("Test") {
     dir("testing/expected-results") {
       withEnv(newenv) {
         sh "./runTests"
@@ -34,7 +34,7 @@ melt.trynode('ableC') {
         sh "./build-all"
       }
     }
-  }*/
+  }
 
   stage ("Integration") {
     // All known, stable extensions to build downstream
@@ -63,13 +63,11 @@ melt.trynode('ableC') {
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
     tasks << extensions.collectEntries { t ->
-            [(t): { melt.buildProject("/melt-umn/${t}", newargs) }]
+      [(t): { melt.buildProject("/melt-umn/${t}", newargs) }]
     }
-    /*tasks << specific_jobs.collectEntries { t ->
+    tasks << specific_jobs.collectEntries { t ->
       [(t): { melt.buildJob(t, newargs) }]
-    }*/
-
-    print tasks
+    }
     
     parallel tasks
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ melt.trynode('ableC') {
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
     tasks << extensions.collectEntries { t ->
-      [t: { melt.buildProject("/melt-umn/${t}", newargs) }]
+            [(t): { melt.buildProject("/melt-umn/${t}", newargs) }]
     }
     /*tasks << specific_jobs.collectEntries { t ->
       [(t): { melt.buildJob(t, newargs) }]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,11 +62,11 @@ melt.trynode('ableC') {
 
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
-    for (t in extensions) {
-      tasks[t] = { melt.buildProject("/melt-umn/${t}", newargs) }
+    tasks << extensions.collect { t ->
+      [t: { melt.buildProject("/melt-umn/${t}", newargs) }]
     }
-    for (t in specific_jobs) {
-      tasks[t] = { melt.buildJob(t, newargs) }
+    tasks << specific_jobs.collect { t ->
+      [t: { melt.buildJob(t, newargs) }]
     }
     
     parallel tasks

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,10 +62,10 @@ melt.trynode('ableC') {
 
     def tasks = [:]
     def newargs = [ABLEC_BASE: ABLEC_BASE, ABLEC_GEN: ABLEC_GEN] // SILVER_BASE inherited
-    tasks << extensions.collect { t ->
+    tasks << extensions.collectEntries { t ->
       [t: { melt.buildProject("/melt-umn/${t}", newargs) }]
     }
-    tasks << specific_jobs.collect { t ->
+    tasks << specific_jobs.collectEntries { t ->
       [t: { melt.buildJob(t, newargs) }]
     }
     


### PR DESCRIPTION
Apparently groovy captures loop variables by reference.  Instead, the standard pattern to use when constructing a list or map is to use `collect` or `collectEntries`.  