### PR TITLE
Allow '{' terminal to follow type expressions

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/DeclSpecifiers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/DeclSpecifiers.sv
@@ -319,13 +319,13 @@ concrete productions top::FunctionSpecifier_c
 
 closed nonterminal StructOrUnionSpecifier_c with location, realTypeSpecifiers, givenQualifiers; 
 concrete productions top::StructOrUnionSpecifier_c
-| su::StructOrUnion_c id::Identifier_c '{' ss::StructDeclarationList_c '}'
+| su::StructOrUnion_c id::Identifier_c TypeLCurly_t ss::StructDeclarationList_c '}'
     { top.realTypeSpecifiers =
         case su of
         | struct_c(_) -> [ast:structTypeExpr(top.givenQualifiers, ast:structDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         | union_c(_) -> [ast:unionTypeExpr(top.givenQualifiers, ast:unionDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         end; }
-| su::StructOrUnion_c '{' ss::StructDeclarationList_c '}'
+| su::StructOrUnion_c TypeLCurly_t ss::StructDeclarationList_c '}'
     { top.realTypeSpecifiers =
         case su of
         | struct_c(_) -> [ast:structTypeExpr(top.givenQualifiers, ast:structDecl(ast:nilAttribute(), ast:nothingName(), ast:foldStructItem(ss.ast), location=top.location))]
@@ -385,13 +385,13 @@ concrete productions top::StructDeclarator_c
 
 closed nonterminal EnumSpecifier_c with location, realTypeSpecifiers, givenQualifiers; 
 concrete productions top::EnumSpecifier_c
-| 'enum' '{' en::EnumeratorList_c '}'
+| 'enum' TypeLCurly_t en::EnumeratorList_c '}'
     { top.realTypeSpecifiers = [ast:enumTypeExpr(top.givenQualifiers, ast:enumDecl(ast:nothingName(), ast:foldEnumItem(en.ast), location=top.location))]; }
-| 'enum' id::Identifier_c '{' en::EnumeratorList_c '}'
+| 'enum' id::Identifier_c TypeLCurly_t en::EnumeratorList_c '}'
     { top.realTypeSpecifiers = [ast:enumTypeExpr(top.givenQualifiers, ast:enumDecl(ast:justName(id.ast), ast:foldEnumItem(en.ast), location=top.location))]; }
-| 'enum' '{' en::EnumeratorList_c ',' '}'
+| 'enum' TypeLCurly_t en::EnumeratorList_c ',' '}'
     { top.realTypeSpecifiers = [ast:enumTypeExpr(top.givenQualifiers, ast:enumDecl(ast:nothingName(), ast:foldEnumItem(en.ast), location=top.location))]; }
-| 'enum' id::Identifier_c '{' en::EnumeratorList_c ',' '}'
+| 'enum' id::Identifier_c TypeLCurly_t en::EnumeratorList_c ',' '}'
     { top.realTypeSpecifiers = [ast:enumTypeExpr(top.givenQualifiers, ast:enumDecl(ast:justName(id.ast), ast:foldEnumItem(en.ast), location=top.location))]; }
 | 'enum' id::Identifier_c
     { top.realTypeSpecifiers = [ast:tagReferenceTypeExpr(top.givenQualifiers, ast:enumSEU(), id.ast)]; }

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
@@ -164,6 +164,10 @@ concrete productions top::Expr_c
     { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
         "Placeholder for TypeNames_c should not appear in the tree.") ],
         location=top.location ) ; }
+| 'TypeNames_NEVER_t!!!nevernever1234567890' TypeNames_c AllowSEUDecl_t
+    { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
+        "Placeholder for TypeNames_c should not appear in the tree.") ],
+        location=top.location ) ; }
 | 'Names_NEVER_t!!!nevernever1234567890' Names_c ')'
     { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
         "Placeholder for Names_c should not appear in the tree.") ],

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
@@ -139,7 +139,7 @@ concrete productions top::Names_c
 | 
   { top.ast = []; }
 
--- Ugly hack to add things to the follow set TypeNames_c and Names_c
+-- Ugly hack to add things to the follow sets of TypeNames_c and Names_c
 -- We set this to include what is allowed by C++ for extensions to use
 terminal TypeNames_NEVER_t 'TypeNames_NEVER_t!!!nevernever1234567890';
 terminal Names_NEVER_t 'Names_NEVER_t!!!nevernever1234567890';

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Declarations.sv
@@ -148,6 +148,10 @@ concrete productions top::Expr_c
     { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
         "Placeholder for TypeNames_c should not appear in the tree.") ],
         location=top.location ) ; }
+| 'TypeNames_NEVER_t!!!nevernever1234567890' TypeNames_c '{'
+    { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
+        "Placeholder for TypeNames_c should not appear in the tree.") ],
+        location=top.location ) ; }
 | 'TypeNames_NEVER_t!!!nevernever1234567890' TypeNames_c '}'
     { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
         "Placeholder for TypeNames_c should not appear in the tree.") ],

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Expr.sv
@@ -600,3 +600,10 @@ concrete productions top::Constant_c
 | c::CharConstantUBig_t
     { top.ast = ast:characterConstant(c.lexeme, ast:char32CharPrefix(), location=top.location); }
 
+-- Ugly hack to add things to the follow set Expr_c
+terminal Expr_NEVER_t 'Expr_NEVER_t!!!nevernever1234567890';
+concrete productions top::Expr_c
+| 'Expr_NEVER_t!!!nevernever1234567890' Expr_c  AllowSEUDecl_t
+    { top.ast = ast:errorExpr ( [ err (top.location, "Internal Error. " ++
+        "Placeholder for Expr_c should not appear in the tree.") ],
+        location=top.location ) ; }

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -224,10 +224,14 @@ terminal LCurly_t      '{'  action { context = head(context) :: context; };
 terminal TypeLCurly_t  /{/  action { context = head(context) :: context; }; -- { used in types, e.g. struct {...
 terminal RCurly_t      '}'  action { context = tail(context); };
 
--- Not ambigous in the host since '{' never follows a type, but we allow this to
--- be done by extensions since it is permitted in C++.
+parser attribute allowStructEnumUnionDecl :: Boolean
+  action { allowStructEnumUnionDecl = true; };
+
+terminal AllowSEUDecl_t '' action { allowStructEnumUnionDecl = true; };
+terminal DisallowSEUDecl_t '' action { allowStructEnumUnionDecl = false; };
+
 disambiguate LCurly_t, TypeLCurly_t {
-  pluck LCurly_t;
+  pluck if allowStructEnumUnionDecl then TypeLCurly_t else LCurly_t;
 }
 
 terminal Question_t    '?';

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -221,7 +221,14 @@ terminal RParen_t      ')' precedence = 1, association = left; -- evidently, par
 terminal LBracket_t    '[';
 terminal RBracket_t    ']';
 terminal LCurly_t      '{'  action { context = head(context) :: context; };
+terminal TypeLCurly_t  /{/  action { context = head(context) :: context; }; -- { used in types, e.g. struct {...
 terminal RCurly_t      '}'  action { context = tail(context); };
+
+-- Not ambigous in the host since '{' never follows a type, but we allow this to
+-- be done by extensions since it is permitted in C++.
+disambiguate LCurly_t, TypeLCurly_t {
+  pluck LCurly_t;
+}
 
 terminal Question_t    '?';
 terminal Colon_t       ':';

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -224,6 +224,15 @@ terminal LCurly_t      '{'  action { context = head(context) :: context; };
 terminal TypeLCurly_t  /{/  action { context = head(context) :: context; }; -- { used in types, e.g. struct {...
 terminal RCurly_t      '}'  action { context = tail(context); };
 
+{- In the standard C grammar, '{' can never follow a type expression.
+ - In C++ this is allowed, and we would like to allow the same for extensions.
+ - Doing so directly results in shift/reduce conflicts between struct/enum/
+ - union references and declarations that can't be resolved one way via
+ - precedence.
+ - Instead, we introduce a distinct TypeLCurly_t terminal to be used in these
+ - declarations that is lexically ambigous with '{', and use a parser attribute
+ - to control whether it is allowed to occur.
+ -}
 parser attribute allowStructEnumUnionDecl :: Boolean
   action { allowStructEnumUnionDecl = true; };
 

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -221,7 +221,6 @@ terminal RParen_t      ')' precedence = 1, association = left; -- evidently, par
 terminal LBracket_t    '[';
 terminal RBracket_t    ']';
 terminal LCurly_t      '{'  action { context = head(context) :: context; };
-terminal TypeLCurly_t  /{/  action { context = head(context) :: context; }; -- { used in types, e.g. struct {...
 terminal RCurly_t      '}'  action { context = tail(context); };
 
 {- In the standard C grammar, '{' can never follow a type expression.
@@ -233,6 +232,8 @@ terminal RCurly_t      '}'  action { context = tail(context); };
  - declarations that is lexically ambigous with '{', and use a parser attribute
  - to control whether it is allowed to occur.
  -}
+terminal TypeLCurly_t  /{/  action { context = head(context) :: context; };
+
 parser attribute allowStructEnumUnionDecl :: Boolean
   action { allowStructEnumUnionDecl = true; };
 
@@ -273,7 +274,7 @@ terminal LEFT_OP       '<<'    lexer classes {Csymbol};
 
 -- Numerical operators
 terminal Minus_t       '-'  precedence = 5, association = left, lexer classes {Csymbol}; -- negative
-terminal Plus_t        '+'  precedence = 5, association = left,  lexer classes {Csymbol}; -- positive
+terminal Plus_t        '+'  precedence = 5, association = left, lexer classes {Csymbol}; -- positive
 terminal Star_t        '*'  precedence = 6, association = left, lexer classes {Csymbol}; -- pointer, deref
 terminal Divide_t      '/'  precedence = 6, association = left, lexer classes {Csymbol};
 terminal Mod_t         '%';

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/c11/C11.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/c11/C11.sv
@@ -149,13 +149,13 @@ concrete productions top::UnaryExpr_c
 
 -- Anonymous struct/union
 concrete productions top::StructDeclaration_c
-| su::StructOrUnion_c id::Identifier_c '{' ss::StructDeclarationList_c '}' ';'
+| su::StructOrUnion_c id::Identifier_c TypeLCurly_t ss::StructDeclarationList_c '}' ';'
     { top.ast =
         case su of
         | struct_c(_) -> [ast:anonStructStructItem(ast:structDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         | union_c(_) -> [ast:anonUnionStructItem(ast:unionDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         end; }
-| su::StructOrUnion_c '{' ss::StructDeclarationList_c '}' ';'
+| su::StructOrUnion_c TypeLCurly_t ss::StructDeclarationList_c '}' ';'
     { top.ast =
         case su of
         | struct_c(_) -> [ast:anonStructStructItem(ast:structDecl(ast:nilAttribute(), ast:nothingName(), ast:foldStructItem(ss.ast), location=top.location))]

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
@@ -223,20 +223,20 @@ concrete productions top::StructDeclarator_c
 
 
 concrete productions top::StructOrUnionSpecifier_c
-| su::StructOrUnion_c aa::Attributes_c id::Identifier_c '{' ss::StructDeclarationList_c '}'
+| su::StructOrUnion_c aa::Attributes_c id::Identifier_c TypeLCurly_t ss::StructDeclarationList_c '}'
     { top.realTypeSpecifiers =
         case su of
         | struct_c(_) -> [ast:structTypeExpr(top.givenQualifiers, ast:structDecl(aa.ast, ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         | union_c(_) -> [ast:unionTypeExpr(top.givenQualifiers, ast:unionDecl(aa.ast, ast:justName(id.ast), ast:foldStructItem(ss.ast), location=top.location))]
         end;
     }
-| su::StructOrUnion_c id::Identifier_c '{' '}'
+| su::StructOrUnion_c id::Identifier_c TypeLCurly_t '}'
     { top.realTypeSpecifiers =
         case su of
         | struct_c(_) -> [ast:structTypeExpr(top.givenQualifiers, ast:structDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem([]), location=top.location))]
         | union_c(_) -> [ast:unionTypeExpr(top.givenQualifiers, ast:unionDecl(ast:nilAttribute(), ast:justName(id.ast), ast:foldStructItem([]), location=top.location))]
         end; }
-| su::StructOrUnion_c '{' '}'
+| su::StructOrUnion_c TypeLCurly_t '}'
     { top.realTypeSpecifiers =
         case su of
         | struct_c(_) -> [ast:structTypeExpr(top.givenQualifiers, ast:structDecl(ast:nilAttribute(), ast:nothingName(), ast:foldStructItem([]), location=top.location))]


### PR DESCRIPTION
This is allowed in C++, for example in a lambda expression `[](void) -> int { ... }`, and so it is desirable to allow extensions to do the same.  
Some annoying hacks were required due to the ambiguity of having a struct reference in the type expression, for example `[](void) -> struct foo { ... }` - it is highly unlikely someone would wish to declare a struct inside the return type of a lambda, so we wish to disallow this.  This was accomplished by making a new '{' terminal for use in struct/enum/union declarations, and clever use of parser attributes to control the disambiguation between these.  