### PR TITLE
Modify typedef production so canonicaltype includes qualifiers

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -805,7 +805,7 @@ top::NoncanonicalType ::= q::Qualifiers  n::String  resolved::Type
     noncanonicalType(
       typedefType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), n, resolved));
 
-  top.canonicalType = addQualifiers(q.qualifiers, resolved);
+  top.canonicalType = resolved;
 }
 
 {-- GCC typeof type expression -}

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -803,7 +803,10 @@ top::NoncanonicalType ::= q::Qualifiers  n::String  resolved::Type
   top.typeModifierExpr = baseTypeExpr();
   top.withTypeQualifiers =
     noncanonicalType(
-      typedefType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), n, resolved));
+      typedefType(
+        foldQualifier(top.addedTypeQualifiers ++ q.qualifiers),
+        n, resolved.withTypeQualifiers));
+  resolved.addedTypeQualifiers = top.addedTypeQualifiers;
 
   top.canonicalType = resolved;
 }
@@ -821,7 +824,10 @@ top::NoncanonicalType ::= q::Qualifiers  resolved::Type
   top.typeModifierExpr = baseTypeExpr();
   top.withTypeQualifiers =
     noncanonicalType(
-      typeofType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), resolved));
+      typeofType(
+        foldQualifier(top.addedTypeQualifiers ++ q.qualifiers),
+        resolved.withTypeQualifiers));
+  resolved.addedTypeQualifiers = top.addedTypeQualifiers;
 }
 
 function filterExtensionQualifiers

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -805,7 +805,7 @@ top::NoncanonicalType ::= q::Qualifiers  n::String  resolved::Type
     noncanonicalType(
       typedefType(foldQualifier(top.addedTypeQualifiers ++ q.qualifiers), n, resolved));
 
-  top.canonicalType = resolved;
+  top.canonicalType = addQualifiers(q.qualifiers, resolved);
 }
 
 {-- GCC typeof type expression -}


### PR DESCRIPTION
Fixes error described in #145. Adds qualifiers to canonicaltype so that modifications caused by qualifiers affect the variable.