### PR TITLE
Fix #152 by removing functionDecls from functionDecl's defs

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
@@ -522,11 +522,7 @@ top::FunctionDecl ::= storage::StorageClasses  fnquals::SpecialSpecifiers  bty::
     globalDeclsDefs(mty.globalDecls) ++
     globalDeclsDefs(ds.globalDecls) ++
     globalDeclsDefs(body.globalDecls) ++
-    globalDeclsDefs(fnquals.globalDecls) ++
-    functionDeclsDefs(mty.functionDecls) ++
-    functionDeclsDefs(ds.functionDecls) ++
-    functionDeclsDefs(body.functionDecls) ++
-    functionDeclsDefs(fnquals.functionDecls);
+    globalDeclsDefs(fnquals.globalDecls);
   top.freeVariables :=
     bty.freeVariables ++
     removeDefsFromNames(implicitDefs, mty.freeVariables) ++


### PR DESCRIPTION
This error is described in detail in #152.
Using the example given there, this fix now results in proper C code where both declarations are injected as desired. 
The issue was caused by adding the functionDecls into the defs attribute from functionDecl production, so that it appeared to other functions as if the declaration had already been injected into global scope. 

This does also identify a larger problem with using `maybeValueDecl` for function scope lifting, which perhaps we should look into solving as well.
We could perhaps solve that by creating a new function `maybeValueFunctionDecl` (or some such name) and having it check only the non-global environment, though that will perpetuate the bug in #150 about nested functions, even further.