### PR TITLE
Fix to qualifier semantics on arrays

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -240,6 +240,10 @@ top::Type ::= element::Type  indexQualifiers::Qualifiers  sizeModifier::ArraySiz
     noncanonicalType(decayedType(top,
       pointerType(indexQualifiers, element)));
   top.withoutExtensionQualifiers = arrayType(element.withoutExtensionQualifiers, filterExtensionQualifiers(indexQualifiers), sizeModifier, sub);
+  -- Added qualfiers go on the element type!
+  top.withTypeQualifiers = arrayType(element.withTypeQualifiers, indexQualifiers, sizeModifier, sub);
+  element.addedTypeQualifiers = top.addedTypeQualifiers;
+  
   top.mergeQualifiers = \t2::Type ->
     case t2 of
       arrayType(element2, q2, _, _) ->


### PR DESCRIPTION
Qualifiers on arrays should go on the element type, as described in the C standard.  For example in the following code
```c
typedef int foo[42];
const foo x;
```
the type of `x` should be `const int[42]` and not `int[42 const]`.  

Note that for decayed types (e.g. in function arguments) qualifiers are attached before the type decays - i.e. in the function
```c
void y(const foo x) {}
```
`x` has type `const int *`, not `int *const` as the type would be if foo were originally defined as `int *`.  

I'm going to merge this as soon as the build passes.  I'm not sure how this affects Travis's work on type qualifiers, but those extensions still seem to build OK.  I don't think that was ever really tested with arrays?