### PR TITLE
Ignore extension terminals in disambiguation logic when parsing system header files

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
@@ -61,7 +61,7 @@ lexer class Scoped
         case shiftableGlobals of
         | [id] -> id
         | ids when lookupBy(terminalSetEq, ids, globalPreferences) matches just(id) -> id
-        | [] -> disambiguationFailure
+        | _ -> disambiguationFailure
         end
       | _ when containsBy(terminalIdEq, Identifier_t, shiftable) -> Identifier_t
       | _ when containsBy(terminalIdEq, TypeName_t, shiftable) -> TypeName_t

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/cppTags/CPPTags.sv
@@ -1,5 +1,5 @@
 grammar edu:umn:cs:melt:ableC:concretesyntax:cppTags;
-
+{-
 -- After the file name comes zero or more flags, which are `1', `2',
 -- `3', or `4'.  If there are multiple flags, spaces separate them.  Here
 -- is what the flags mean:
@@ -22,8 +22,13 @@ synthesized attribute tagIsSystem :: Boolean;
 --     This indicates that the following text should be treated as being
 --     wrapped in an implicit `extern "C"' block.
 synthesized attribute tagIsExternC :: Boolean;
+-}
 
 -- I give up!
+
+parser attribute inSystemHeader::Boolean
+  action { inSystemHeader = false; };
+
 ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\r]?[\n]?)/
   action {
     filename = 
@@ -37,6 +42,16 @@ ignore terminal CPP_Location_Tag_t /\#\ [0-9]+\ \"[^\"]+\"[\ 0-9]*([\r]?[\n]?)/
         indexOf("\"", lexeme) - 1, -- end before <space>"
         lexeme));
     column = 0;
+    
+    local flags::[Integer] =
+      map(\ f::String -> toInteger(f),
+        filter(isDigit,
+          explode(" ",
+            substring(
+              lastIndexOf("\"", lexeme), -- after "
+              length(lexeme),            -- rest of the token
+              lexeme))));
+    inSystemHeader = containsBy(\ a::Integer b::Integer -> a == b, 3, flags);
   };
 
 {-


### PR DESCRIPTION
This was suggested by @remexre.  

When parsing system header files, we would like to avoid conflicts with extensions.  This is mostly achieved through my previous work with lexically scoped disambiguation for extension marking terminals, however extension keywords can show up as ambiguous with identifiers in some places that aren't definitions (e.g. struct field names in a header file.)  

It turns out that the C preprocessor tags contain a convenient way to check if we are in a system header file.  So we can actually just turn off disambiguating to extension terminals (at least ones using the `Global` lexer class mechanism) when we are in a system header file (where the obviously shouldn't be any extension terminals.)  The disambiguation logic is otherwise unchanged.