### PR TITLE
Fix parsing of C11-allowed repeated typedefs

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
@@ -61,7 +61,7 @@ lexer class Scoped
     pluck
       case lookupResult of
       | just(id) ->
-        if id == TypeName_t && seenTypeSpecifier
+        if id == TypeName_t && seenTypeSpecifier && containsBy(terminalIdEq, Identifier_t, shiftable)
         then Identifier_t
         else id
       | nothing() when !inSystemHeader && !null(shiftableGlobals) ->

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/LexerHack.sv
@@ -46,17 +46,24 @@ lexer class Scoped
     
     {- In order of preference:
      - * Looked-up terminal from context
-     - * Any valid, unambigous terminal from Global lexer class (if not in a system header file)
+     -   * If the name has previously been defined as a TypeName_t and we have already seen a
+           specifier in the current specifier list, then return Identifier_t instead (needed to
+           handle C11 typedef re-declarations)
+     - * Any valid, unambigous terminal from the Global lexer class (if not in a system header file)
      -   * If there are more than one, check the globalPrerences parser attribute
-     -   * Otherwise, fail (this is a conflict between two extensions that must be resolved with explict preferences/prefixes)
+     -   * Otherwise, fail (this is a conflict between two extensions that must be resolved with
+           explict preferences/prefixes)
      - * Identifier_t, if valid
      - * TypeName_t, if valid
      - * Any (arbitrary) thing that is valid: if the parse succeeds there will
-     -   be a (better) semantic error.
+     -   be a semantic error that is better than a syntax error.
      -}
     pluck
       case lookupResult of
-      | just(id) -> id
+      | just(id) ->
+        if id == TypeName_t && seenTypeSpecifier
+        then Identifier_t
+        else id
       | nothing() when !inSystemHeader && !null(shiftableGlobals) ->
         case shiftableGlobals of
         | [id] -> id

--- a/testing/expected-results/neutral
+++ b/testing/expected-results/neutral
@@ -1,20 +1,19 @@
 Positive test       - FAIL: ERROR       tests/kframework/neutral/j009h.c
-Positive test       - FAIL: ERROR       tests/melt/neutral/typedef-c11-redeclaration.c
+Positive test       - PASS:             tests/melt/neutral/typedef-c11-redeclaration.c
 
 Failures:
             ERROR
                         tests/kframework/neutral/j009h.c
-                        tests/melt/neutral/typedef-c11-redeclaration.c
 
 Positive tests:
-Pass: 0
-Fail: 2
+Pass: 1
+Fail: 1
 
 Negative tests:
 Pass: 0
 Fail: 0
 
 Summary:
-Pass: 0
-Fail: 2
+Pass: 1
+Fail: 1
 

--- a/testing/tests/melt/neutral/typedef-c11-redeclaration.c
+++ b/testing/tests/melt/neutral/typedef-c11-redeclaration.c
@@ -3,15 +3,12 @@
 typedef int foo;
 
 // C11 legal redefinition of non-variably modified type.
-// This parses, but incorrectly: as 'storage-class type-spec type-spec' with no identifier.
 typedef int foo;
 
 // Again, should be legal.
-// This parses *correctly*. 'storage-class type-spec ident ident'
 typedef int bar, foo;
 
 // Again, should be legal.
-// This fails to parse. it sees 'storage-class type-spec type-spec' and dies at the comma
 typedef int foo, bar;
 
 


### PR DESCRIPTION
This fixes a long-standing bug where C11-allowed repeated `typedef`s were parsed incorrectly.  Recall that declarations are parsed as a sequence of declaration specifiers followed by a list of declarators.  Consider the program
```c
typedef int a;
typedef int a;
```
Currently we correctly in first `typedef` we parse the declaration specifiers `typedef` and `int`, then there is an ambiguity at `a` as it could be a type name as an additional type specifier, or an identifier as a declarator.  Since `a` has no definition we correctly disambiguate it as an identifier/declarator.  

However in parsing the second `typedef`, when we reach `a` we see that it has a definition in the context as a type name, and parse it as another type specifier!  This is a syntactically valid parse which results in a semantic error, as it is illegal for a declaration to contain multiple "real" type specifiers.  

The fix for this is that as soon as we parse a type specifier in a declaration specifier list, ambiguities between type names and identifiers for names that are in the context as types should be resolved as identifiers.  This required a bit of slight grammar restructuring, a new parser attribute, and yet another case in the disambugation class for identifiers.

The downside to this is that there are few cases that formerly were semantic errors that are now parse errors.  For example
```
typedef int a;
typedef int a b;
```
would previously give a semantic error about "multiple type specifiers" on the second typedef, but now would give a parse error at `b`, since the `a` would be disambiguated as an identifier declarator rather than another type specifier.  