### PR TITLE
Trying out implicit monads in ableC - make integerConstantValue implicit

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
@@ -1,5 +1,7 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax:env;
 
+import core:monad;
+
 closed nonterminal ValueItem with typerep, sourceLocation, directRefHandler, directCallHandler, isItemValue, isItemType, integerConstantValue;
 
 synthesized attribute sourceLocation :: Location;
@@ -71,7 +73,7 @@ top::ValueItem ::= e::Decorated EnumItem
   top.typerep = e.typerep;
   top.sourceLocation = e.sourceLocation;
   top.isItemValue = true;
-  top.integerConstantValue = just(e.enumItemValue);
+  top.integerConstantValue = e.enumItemValue;
 }
 
 abstract production parameterValueItem

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
@@ -17,7 +17,7 @@ top::ValueItem ::=
   top.directCallHandler = ordinaryFunctionHandler;
   top.isItemValue = false;
   top.isItemType = false;
-  top.integerConstantValue = nothing();
+  implicit top.integerConstantValue = ;
 }
 
 -- TODO: we might consider splitting this into values and typedef names.

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
@@ -840,8 +840,8 @@ StructItemList ::= s1::StructItemList s2::StructItemList
 autocopy attribute appendedEnumItemList :: EnumItemList;
 synthesized attribute appendedEnumItemListRes :: EnumItemList;
 
-inherited attribute enumItemValueIn::Integer;
-synthesized attribute enumItemValue::Integer;
+restricted inherited attribute enumItemValueIn::Integer;
+restricted synthesized attribute enumItemValue::Integer;
 
 nonterminal EnumItemList with pps, host, errors, globalDecls, functionDecls, defs, env, containingEnum, returnType, freeVariables, appendedEnumItemList, appendedEnumItemListRes, enumItemValueIn;
 flowtype EnumItemList = decorate {env, containingEnum, enumItemValueIn, returnType}, appendedEnumItemListRes {appendedEnumItemList};

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
@@ -854,6 +854,7 @@ StructItemList ::= s1::StructItemList s2::StructItemList
 autocopy attribute appendedEnumItemList :: EnumItemList;
 synthesized attribute appendedEnumItemListRes :: EnumItemList;
 
+-- These are restricted since they are used by the implicit integerConstantValue attribute
 restricted inherited attribute enumItemValueIn::Integer;
 restricted synthesized attribute enumItemValue::Integer;
 

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -10,14 +10,14 @@ flowtype Expr = decorate {env, returnType}, isLValue {decorate}, isSimple {decor
 
 synthesized attribute isLValue::Boolean;
 synthesized attribute isSimple::Boolean; -- true if expression can be duplicated without encurring any addtional work (is a name, constant, field access, etc.)
-synthesized attribute integerConstantValue::Maybe<Integer>;
+implicit synthesized attribute integerConstantValue::Maybe<Integer>;
 
 aspect default production
 top::Expr ::=
 {
   top.isLValue = false;
   top.isSimple = false;
-  top.integerConstantValue = nothing();
+  implicit top.integerConstantValue = ;
 }
 
 abstract production errorExpr
@@ -311,12 +311,9 @@ top::Expr ::= cond::Expr  t::Expr  e::Expr
   top.typerep = t.typerep; -- TODO: this is wrong, but it's an approximation for now
   
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- cond.integerConstantValue;
-      i2::Integer <- t.integerConstantValue;
-      i3::Integer <- e.integerConstantValue;
-      return if i1 != 0 then i2 else i3;
-    };
+    if cond.integerConstantValue != 0
+    then t.integerConstantValue
+    else e.integerConstantValue;
   
   t.env = addEnv(cond.defs, cond.env);
   e.env = addEnv(t.defs, t.env);
@@ -333,11 +330,9 @@ top::Expr ::= cond::Expr  e::Expr
   top.typerep = e.typerep; -- TODO: not even sure what this should be
   
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- cond.integerConstantValue;
-      i2::Integer <- e.integerConstantValue;
-      return if i1 != 0 then i1 else i2;
-    };
+    if cond.integerConstantValue != 0
+    then cond.integerConstantValue
+    else e.integerConstantValue;
   
   -- TODO: type checking!!
 }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprBinOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprBinOps.sv
@@ -193,11 +193,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 != 0 && i2 != 0 then 1 else 0;
-    };
+    if lhs.integerConstantValue != 0 && rhs.integerConstantValue != 0 then 1 else 0;
 }
 
 abstract production orExpr
@@ -212,11 +208,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 != 0 || i2 != 0 then 1 else 0;
-    };
+    if lhs.integerConstantValue != 0 || rhs.integerConstantValue != 0 then 1 else 0;
 }
 
 abstract production andBitExpr
@@ -230,12 +222,10 @@ top::Expr ::= lhs::Expr rhs::Expr
   top.typerep = usualArithmeticConversionsOnTypes(lhs.typerep, rhs.typerep);
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
-  top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return fromBits(zipWithPad(\ a::Boolean b::Boolean -> a && b, false, toBits(i1), toBits(i2)));
-    };
+  top.integerConstantValue = fromBits(
+      zipWithPad(\ a::Boolean b::Boolean -> a && b, false,
+        toBits(lhs.integerConstantValue),
+        toBits(rhs.integerConstantValue)));
 }
 
 abstract production orBitExpr
@@ -249,12 +239,10 @@ top::Expr ::= lhs::Expr rhs::Expr
   top.typerep = usualArithmeticConversionsOnTypes(lhs.typerep, rhs.typerep);
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
-  top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return fromBits(zipWithPad(\ a::Boolean b::Boolean -> a || b, false, toBits(i1), toBits(i2)));
-    };
+  top.integerConstantValue = fromBits(
+      zipWithPad(\ a::Boolean b::Boolean -> a || b, false,
+        toBits(lhs.integerConstantValue),
+        toBits(rhs.integerConstantValue)));
 }
 
 abstract production xorExpr
@@ -268,12 +256,10 @@ top::Expr ::= lhs::Expr rhs::Expr
   top.typerep = usualArithmeticConversionsOnTypes(lhs.typerep, rhs.typerep);
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
-  top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return fromBits(zipWithPad(\ a::Boolean b::Boolean -> (a && !b) || (!a && b), false, toBits(i1), toBits(i2)));
-    };
+  top.integerConstantValue = fromBits(
+      zipWithPad(\ a::Boolean b::Boolean -> (a && !b) || (!a && b), false,
+        toBits(lhs.integerConstantValue),
+        toBits(rhs.integerConstantValue)));
 }
 
 abstract production lshExpr
@@ -288,11 +274,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return foldr(\ Unit i::Integer -> i * 2, i1, repeat(unit(), i2));
-    };
+    foldr(\ Unit i::Integer -> i * 2, lhs.integerConstantValue, repeat(unit(), rhs.integerConstantValue));
 }
 
 abstract production rshExpr
@@ -307,11 +289,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return foldr(\ Unit i::Integer -> i / 2, i1, repeat(unit(), i2));
-    };
+    foldr(\ Unit i::Integer -> i / 2, lhs.integerConstantValue, repeat(unit(), rhs.integerConstantValue));
 }
 
 abstract production equalsExpr
@@ -326,11 +304,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 == i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue == rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production notEqualsExpr
@@ -345,11 +319,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 != i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue != rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production gtExpr
@@ -364,11 +334,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 > i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue > rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production ltExpr
@@ -383,11 +349,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 < i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue < rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production gteExpr
@@ -402,11 +364,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 >= i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue >= rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production lteExpr
@@ -421,11 +379,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return if i1 <= i2 then 1 else 0;
-    };
+    if lhs.integerConstantValue <= rhs.integerConstantValue then 1 else 0;
 }
 
 abstract production addExpr
@@ -440,11 +394,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return i1 + i2;
-    };
+    lhs.integerConstantValue + rhs.integerConstantValue;
 }
 
 abstract production subExpr
@@ -459,11 +409,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return i1 - i2;
-    };
+    lhs.integerConstantValue - rhs.integerConstantValue;
 }
 
 abstract production mulExpr
@@ -478,11 +424,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return i1 * i2;
-    };
+    lhs.integerConstantValue * rhs.integerConstantValue;
 }
 
 abstract production divExpr
@@ -497,11 +439,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return i1 / i2;
-    };
+    lhs.integerConstantValue / rhs.integerConstantValue;
 }
 
 abstract production modExpr
@@ -516,11 +454,7 @@ top::Expr ::= lhs::Expr rhs::Expr
   rhs.env = addEnv(lhs.defs, lhs.env);
   top.isLValue = false;
   top.integerConstantValue =
-    do (bindMaybe, returnMaybe) {
-      i1::Integer <- lhs.integerConstantValue;
-      i2::Integer <- rhs.integerConstantValue;
-      return i1 % i2;
-    };
+    lhs.integerConstantValue % rhs.integerConstantValue;
 }
 
 abstract production commaExpr

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
@@ -27,7 +27,7 @@ top::MaybeExpr ::=
   top.justTheExpr = nothing();
   top.maybeTyperep = nothing();
   top.isLValue = false;
-  top.integerConstantValue = nothing();
+  implicit top.integerConstantValue = ;
 }
 
 nonterminal Exprs with pps, host, errors, globalDecls, functionDecls, defs, env, expectedTypes, argumentPosition, callExpr, argumentErrors, typereps, count, callVariadic, returnType, freeVariables, appendedExprs, appendedRes, isLValue;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
@@ -1,5 +1,7 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
+import core:monad;
+
 nonterminal MaybeExpr with pp, host, isJust, errors, globalDecls, functionDecls, defs, env, maybeTyperep, returnType, freeVariables, justTheExpr, isLValue, integerConstantValue;
 
 flowtype MaybeExpr = decorate {env, returnType}, isJust {}, justTheExpr {}, maybeTyperep {decorate}, integerConstantValue {decorate};

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprUnaryOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprUnaryOps.sv
@@ -1,5 +1,7 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
+import core:monad;
+
 abstract production preIncExpr
 top::Expr ::= e::Expr
 {
@@ -95,7 +97,7 @@ top::Expr ::= e::Expr
   propagate host, errors, globalDecls, functionDecls, defs, freeVariables;
   top.pp = parens( cat( text("-"), e.pp ) );
   top.typerep = e.typerep.defaultLvalueConversion.integerPromotions;
-  top.integerConstantValue = mapMaybe(\ i::Integer -> -i, e.integerConstantValue);
+  top.integerConstantValue = -e.integerConstantValue;
 }
 abstract production bitNegateExpr
 top::Expr ::= e::Expr
@@ -111,7 +113,7 @@ top::Expr ::= e::Expr
   propagate host, errors, globalDecls, functionDecls, defs, freeVariables;
   top.pp = parens( cat( text("!"), e.pp ) );
   top.typerep = e.typerep.defaultLvalueConversion.integerPromotions;
-  top.integerConstantValue = mapMaybe(\ i::Integer -> if i != 0 then 1 else 0, e.integerConstantValue);
+  top.integerConstantValue = if e.integerConstantValue != 0 then 1 else 0;
 }
 
 -- GCC extension

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
@@ -17,9 +17,9 @@ synthesized attribute valueLookupCheck :: [Message];
 synthesized attribute tagLookupCheck :: [Message];
 synthesized attribute labelLookupCheck :: [Message];
 
-synthesized attribute valueItem :: Decorated ValueItem;
-synthesized attribute tagItem :: Decorated TagItem;
-synthesized attribute labelItem :: Decorated LabelItem;
+restricted synthesized attribute valueItem :: Decorated ValueItem;
+restricted synthesized attribute tagItem :: Decorated TagItem;
+restricted synthesized attribute labelItem :: Decorated LabelItem;
 
 nonterminal Name with location, name, pp, host, env, valueLocalLookup, labelRedeclarationCheck, valueLookupCheck, tagLookupCheck, labelLookupCheck, valueItem, tagItem, labelItem, tagLocalLookup, tagHasForwardDcl, tagRefId, valueRedeclarationCheck, valueRedeclarationCheckNoCompatible, valueMergeRedeclExtnQualifiers;
 flowtype Name = decorate {env}, name {}, valueLocalLookup {env}, labelRedeclarationCheck {env}, valueLookupCheck {env}, tagLookupCheck {env}, labelLookupCheck {env}, valueItem {env}, tagItem {env}, labelItem {env}, tagLocalLookup {env}, tagHasForwardDcl {env}, tagRefId {env}, valueRedeclarationCheck {decorate}, valueRedeclarationCheckNoCompatible {decorate}, valueMergeRedeclExtnQualifiers {decorate};


### PR DESCRIPTION
See title - this makes the `integerConstantValue` attribute `implicit` (and a few other attributes `restricted` as needed.)  

Implicit monads are a pretty cool feature - this saves a fair number of annoying boilerplate `do`-expressions.  