### PR TITLE
Fix Type-Checking Problems with _Atomic types

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeOps.sv
@@ -67,6 +67,9 @@ Boolean ::= a::Type  b::Type  allowSubtypes::Boolean  dropOuterQual::Boolean
   -- otherwise
   | noncanonicalType(s1), _ -> compatibleTypes(s1.canonicalType, b, allowSubtypes, dropOuterQual)
   | _, noncanonicalType(s2) -> compatibleTypes(a, s2.canonicalType, allowSubtypes, dropOuterQual)
+  -- atomics
+  | atomicType(q1, t1), _ -> compatibleTypes((decorate t1 with {addedTypeQualifiers=q1.qualifiers;}).withTypeQualifiers, b, allowSubtypes, dropOuterQual)
+  | _, atomicType(q2, t2) -> compatibleTypes(a, (decorate t2 with {addedTypeQualifiers=q2.qualifiers;}).withTypeQualifiers, allowSubtypes, dropOuterQual)
   | _, _ -> false
   end;
 }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Types.sv
@@ -578,6 +578,11 @@ top::Type ::= q::Qualifiers  bt::Type
     end;
   top.qualifiers = q.qualifiers;
   q.typeToQualify = top;
+
+  top.isIntegerType = bt.isIntegerType;
+  top.isScalarType = bt.isScalarType;
+  top.isArithmeticType = bt.isArithmeticType;
+  top.isCompleteType = bt.isCompleteType;
 }
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
This is attempting to fix errors in ableC that caused all assignments involving `_Atomic` types (atleast `_Atomic int`) to result in type errors. It seems that there were two issues, one that the atomicType production was not providing equations for isArithmeticType (and other similar attributes) based on the base type and that the `compatibleTypes` function only considered types compatible if both were atomic.

A simple example that failed previously but succeeds now:
```
int main() {
  _Atomic int x = 2;
  return 0;
}
```

This solution may not be ideal because it allows the `_Atomic` to be discarded easily and while GCC doesn't seem to complain about implicit casting of `int` to `_Atomic int`, it goes warn about implicit casting between `_Atomic int*` and `int*`. I don't know if we have access to the actual C11 standard, but if we do it might be worth checking how type-checking with atomics is supposed to work.