### PR TITLE
Add error checking for the placement of break and continue

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/construction/FoldHelpers.sv
@@ -73,7 +73,8 @@ Parameters ::= l::[ParameterDecl]
   return case l of
   -- A special case.  "type name(void)"  means no parameters.
   | [d] ->
-    case decorate d with {env = emptyEnv(); returnType = nothing(); position = 0;} of
+    case decorate d with {env = emptyEnv(); returnType = nothing(); position = 0; 
+            breakValid=false; continueValid=false;} of
       parameterDecl(nilStorageClass(), builtinTypeExpr(nilQualifier(), voidType()), baseTypeExpr(), nothingName(), nilAttribute()) -> nilParameters()
     | _ -> foldr(consParameters, nilParameters(), l)
     end

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/AsmConstruct.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/AsmConstruct.sv
@@ -2,8 +2,9 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
 propagate host on AsmStatement, AsmArgument, AsmClobbers, AsmOperands, AsmOperand;
 
-nonterminal AsmStatement with location, pp, host, env, returnType, freeVariables;
-flowtype AsmStatement = decorate {env, returnType};
+nonterminal AsmStatement with location, pp, host, env, returnType, freeVariables,
+  breakValid, continueValid;
+flowtype AsmStatement = decorate {env, returnType, breakValid, continueValid};
 
 abstract production asmStatement
 a::AsmStatement ::= arg::AsmArgument
@@ -19,20 +20,21 @@ a::AsmStatement ::= tq::Qualifier arg::AsmArgument
   a.freeVariables := arg.freeVariables;
 }
 
-nonterminal AsmArgument with location, pp, host, env, returnType, freeVariables;
-flowtype AsmArgument = decorate {env, returnType};
+nonterminal AsmArgument with location, pp, host, env, returnType, freeVariables,
+  breakValid, continueValid;
+flowtype AsmArgument = decorate {env, returnType, breakValid, continueValid};
 
 abstract production asmArgument
 top::AsmArgument ::= s::String asmOps1::AsmOperands asmOps2::AsmOperands asmC::AsmClobbers
 {
   top.pp = ppConcat( [ text(s) ]
-             ++ (if asmOps1.exists || asmOps2.exists || asmC.exists then [text(": ")] else [ ])  
+             ++ (if asmOps1.exists || asmOps2.exists || asmC.exists then [text(": ")] else [ ])
              ++ [asmOps1.pp]
              ++ (if asmOps2.exists || asmC.exists then [text(": ")] else [ ])
-             ++ [asmOps2.pp] 
+             ++ [asmOps2.pp]
              ++ (if asmC.exists then [text(": ")] else [ ])
-             ++ [asmC.pp] 
-             ) ;  
+             ++ [asmC.pp]
+             ) ;
   top.freeVariables := asmOps1.freeVariables ++ asmOps2.freeVariables;
 }
 
@@ -41,30 +43,31 @@ synthesized attribute exists::Boolean;
 nonterminal AsmClobbers with location, pp, exists, host;
 flowtype AsmClobbers = decorate {}, exists {};
 
-abstract production noneAsmClobbers 
+abstract production noneAsmClobbers
 top::AsmClobbers ::=
 {
   top.exists = false;
   top.pp = notext();
 }
-abstract production oneAsmClobbers 
+abstract production oneAsmClobbers
 top::AsmClobbers ::= s::String
 {
   top.exists = true;
   top.pp = text(s);
 }
-abstract production snocAsmClobbers 
+abstract production snocAsmClobbers
 top::AsmClobbers ::= asmC::AsmClobbers s::String
 {
   top.exists = true;
   top.pp = ppConcat( [asmC.pp, text(", "), text(s) ] );
 }
 
-nonterminal AsmOperands with location, pp, exists, host, env, returnType, freeVariables;
-flowtype AsmOperands = decorate {env, returnType}, exists {};
+nonterminal AsmOperands with location, pp, exists, host, env, returnType,
+  freeVariables, breakValid, continueValid;
+flowtype AsmOperands = decorate {env, returnType, breakValid, continueValid}, exists {};
 
 abstract production noneAsmOps
-top::AsmOperands ::= 
+top::AsmOperands ::=
 {
   top.pp = notext();
   top.exists = false;
@@ -85,8 +88,9 @@ top::AsmOperands ::= asmOps::AsmOperands asmOp::AsmOperand
   top.freeVariables := asmOp.freeVariables ++ asmOps.freeVariables;
 }
 
-nonterminal AsmOperand with location, pp, host, env, returnType, freeVariables;
-flowtype AsmOperand = decorate {env, returnType};
+nonterminal AsmOperand with location, pp, host, env, returnType, freeVariables,
+  breakValid, continueValid;
+flowtype AsmOperand = decorate {env, returnType, breakValid, continueValid};
 
 abstract production asmOperand
 top::AsmOperand ::= s::String e::Expr
@@ -98,6 +102,6 @@ top::AsmOperand ::= s::String e::Expr
 abstract production asmOperandId
 top::AsmOperand ::= id::Name  s::String e::Expr
 {
-  top.pp = ppConcat( [ text("["), id.pp, text("] "), text(s), text(" ("), e.pp, text(")") ] ); 
+  top.pp = ppConcat( [ text("["), id.pp, text("] "), text(s), text(" ("), e.pp, text(")") ] );
   top.freeVariables := e.freeVariables;
 }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Attribute.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Attribute.sv
@@ -23,8 +23,8 @@ Attributes ::= l1::Attributes l2::Attributes
 
 propagate host on Attributes, Attribute, Attrib, AttribName;
 
-nonterminal Attributes with pps, host, env, returnType;
-flowtype Attributes = decorate {env, returnType};
+nonterminal Attributes with pps, host, env, returnType, breakValid, continueValid;
+flowtype Attributes = decorate {env, returnType, breakValid, continueValid};
 
 abstract production consAttribute
 top::Attributes ::= h::Attribute t::Attributes
@@ -33,14 +33,14 @@ top::Attributes ::= h::Attribute t::Attributes
 }
 
 abstract production nilAttribute
-top::Attributes ::= 
+top::Attributes ::=
 {
   top.pps = [];
 }
 
 {-- __attribute__ syntax representation -}
-nonterminal Attribute with pp, host, env, returnType;
-flowtype Attribute = decorate {env, returnType};
+nonterminal Attribute with pp, host, env, returnType, breakValid, continueValid;
+flowtype Attribute = decorate {env, returnType, breakValid, continueValid};
 
 abstract production gccAttribute
 top::Attribute ::= l::Attribs
@@ -54,8 +54,8 @@ top::Attribute ::= s::String
   top.pp = text("__asm__(" ++ s ++ ")");
 }
 
-nonterminal Attribs with pp, host, env, returnType;
-flowtype Attribs = decorate {env, returnType};
+nonterminal Attribs with pp, host, env, returnType, breakValid, continueValid;
+flowtype Attribs = decorate {env, returnType, breakValid, continueValid};
 
 abstract production consAttrib
 top::Attribs ::= h::Attrib t::Attribs
@@ -69,14 +69,14 @@ top::Attribs ::= h::Attrib t::Attribs
 }
 
 abstract production nilAttrib
-top::Attribs ::= 
+top::Attribs ::=
 {
   propagate host;
   top.pp = text("");
 }
 
-nonterminal Attrib with pp, host, env, returnType;
-flowtype Attrib = decorate {env, returnType};
+nonterminal Attrib with pp, host, env, returnType, breakValid, continueValid;
+flowtype Attrib = decorate {env, returnType, breakValid, continueValid};
 
 -- e.g. __attribute__(())
 abstract production emptyAttrib

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/AttributeAnimation.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/AttributeAnimation.sv
@@ -8,8 +8,8 @@ Type ::= attr::Decorated Attributes  ty::Type
     | consAttribute(gccAttribute(l), t) -> animateAttribOnType(l, animateAttributeOnType(t, ty))
     | consAttribute(h, t) ->
       case animateAttributeOnType(t, ty) of
-      | attributedType(attr, t) -> attributedType(consAttribute(h, attr), t) 
-      | t -> attributedType(consAttribute(h, nilAttribute()), t) 
+      | attributedType(attr, t) -> attributedType(consAttribute(h, attr), t)
+      | t -> attributedType(consAttribute(h, nilAttribute()), t)
       end
     | nilAttribute() -> ty
     end;
@@ -24,16 +24,16 @@ Type ::= attr::Decorated Attribs  ty::Type
   -- __vector_size__(num)
   | consAttrib(
       appliedAttrib(
-        attribName(name("__vector_size__")), 
+        attribName(name("__vector_size__")),
         consExpr(realConstant(integerConstant(num, _, _)), nilExpr())),
       t) -> animateAttribOnType(t, vectorType(ty, toInteger(num)))
-  
+
   -- Attribs that should not be attatched
   -- refId(name)
   | consAttrib( appliedAttrib(attribName(name("refId")), _), t) -> animateAttribOnType(t, ty)
-  
+
   -- TODO: There are probably more that should be discarded here, figure out the semantics of this
-  
+
   -- Attatch all other attribs via attributedType
   | consAttrib(h, t) ->
     case animateAttribOnType(t, ty) of
@@ -88,11 +88,13 @@ top::Attrib ::= n::AttribName  e::Exprs
         just(substring(1, length(s) - 1, s))
     | _, _ -> nothing()
     end;
-  
+
   -- Needed since we are matching on Expr
   -- Not a big deal since these are pretty much just constants
   e.env = emptyEnv();
   e.returnType = nothing();
+  e.breakValid = false;
+  e.continueValid = false;
 }
 -- e.g. __attribute__((something(foo, "well whatever")))
 -- OR __attribute__((something(foo)))

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Debug.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Debug.sv
@@ -16,7 +16,7 @@ e::Expr ::= txt::String
 {
   propagate host, errors, globalDecls, functionDecls, defs, freeVariables;
   e.pp = text(txt);
-  e.typerep = errorType(); -- error("Need a type on txtExpr"); 
+  e.typerep = errorType(); -- error("Need a type on txtExpr");
   e.isLValue = false;
 }
 abstract production txtStmt
@@ -48,8 +48,8 @@ e::Expr ::=
   propagate errors, globalDecls, functionDecls, defs;
   e.pp =
     decorate comment("printEnv pp should be demanded through host pp", location=e.location)
-    with {env = e.env;
-          returnType = e.returnType;}.pp;
+    with {env = e.env; returnType = e.returnType;
+        breakValid = e.breakValid; continueValid = e.continueValid;}.pp;
   forwards to comment( show(80,showEnv(e.env)), location=e.location );
 }
 
@@ -60,7 +60,7 @@ Document ::= e::Decorated Env
 {
   return ppConcat( [
     text(" Environment:"),
-    nestlines(5, 
+    nestlines(5,
       ppConcat([
        text("Labels:"),line(),
          nestlines(5, labelsD),

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprBuiltins.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprBuiltins.sv
@@ -27,8 +27,9 @@ top::Expr ::= ty::TypeName  e::MemberDesignator
   top.isSimple = true;
 }
 
-nonterminal MemberDesignator with pp, host, errors, globalDecls, functionDecls, defs, env, returnType, freeVariables;
-flowtype MemberDesignator = decorate {env, returnType};
+nonterminal MemberDesignator with pp, host, errors, globalDecls, functionDecls,
+  defs, env, returnType, freeVariables, breakValid, continueValid;
+flowtype MemberDesignator = decorate {env, returnType, breakValid, continueValid};
 
 propagate host, errors, globalDecls, functionDecls, defs, freeVariables on MemberDesignator;
 
@@ -63,7 +64,7 @@ top::Expr ::= e::Expr
 }
 
 abstract production vaArgPackExpr
-top::Expr ::= 
+top::Expr ::=
 {
   propagate host, errors, globalDecls, functionDecls, defs, freeVariables;
   top.pp = text("__builtin_va_arg_pack()");

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/ExprContainers.sv
@@ -1,8 +1,11 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
-nonterminal MaybeExpr with pp, host, isJust, errors, globalDecls, functionDecls, defs, env, maybeTyperep, returnType, freeVariables, justTheExpr, isLValue, integerConstantValue;
+nonterminal MaybeExpr with pp, host, isJust, errors, globalDecls, functionDecls,
+  defs, env, maybeTyperep, returnType, freeVariables, justTheExpr, isLValue,
+  integerConstantValue, breakValid, continueValid;
 
-flowtype MaybeExpr = decorate {env, returnType}, isJust {}, justTheExpr {}, maybeTyperep {decorate}, integerConstantValue {decorate};
+flowtype MaybeExpr = decorate {env, returnType, breakValid, continueValid},
+  isJust {}, justTheExpr {}, maybeTyperep {decorate}, integerConstantValue {decorate};
 
 synthesized attribute maybeTyperep :: Maybe<Type>;
 synthesized attribute justTheExpr :: Maybe<Expr>;
@@ -30,9 +33,14 @@ top::MaybeExpr ::=
   implicit top.integerConstantValue = ;
 }
 
-nonterminal Exprs with pps, host, errors, globalDecls, functionDecls, defs, env, expectedTypes, argumentPosition, callExpr, argumentErrors, typereps, count, callVariadic, returnType, freeVariables, appendedExprs, appendedRes, isLValue;
+nonterminal Exprs with pps, host, errors, globalDecls, functionDecls, defs, env,
+  expectedTypes, argumentPosition, callExpr, argumentErrors, typereps, count,
+  callVariadic, returnType, freeVariables, appendedExprs, appendedRes, isLValue,
+  breakValid, continueValid;
 
-flowtype Exprs = decorate {env, returnType}, argumentErrors {decorate, expectedTypes, argumentPosition, callExpr, callVariadic}, count {}, appendedRes {appendedExprs};
+flowtype Exprs = decorate {env, returnType, breakValid, continueValid},
+  argumentErrors {decorate, expectedTypes, argumentPosition, callExpr, callVariadic},
+  count {}, appendedRes {appendedExprs};
 
 {-- Initially 1. -}
 inherited attribute argumentPosition :: Integer;
@@ -56,7 +64,7 @@ top::Exprs ::= h::Expr  t::Exprs
   top.count = 1 + t.count;
   top.appendedRes = consExpr(h, t.appendedRes);
   top.isLValue = t.isLValue;
-  
+
   top.argumentErrors =
    if null(top.expectedTypes) then
       if top.callVariadic then []
@@ -75,7 +83,7 @@ top::Exprs ::= h::Expr  t::Exprs
   t.expectedTypes = tail(top.expectedTypes);
   t.argumentPosition = top.argumentPosition + 1;
   t.appendedExprs = top.appendedExprs;
-  
+
   t.env = addEnv(h.defs, h.env);
 }
 abstract production nilExpr
@@ -87,7 +95,7 @@ top::Exprs ::=
   top.count = 0;
   top.appendedRes = top.appendedExprs;
   top.isLValue = false;
-  
+
   top.argumentErrors =
     if null(top.expectedTypes) then []
     else
@@ -125,9 +133,10 @@ Exprs ::= e1::Exprs e2::Exprs
   return e1.appendedRes;
 }
 
-nonterminal ExprOrTypeName with pp, host, errors, globalDecls, functionDecls, defs, env, typerep, returnType, freeVariables, isLValue;
+nonterminal ExprOrTypeName with pp, host, errors, globalDecls, functionDecls,
+  defs, env, typerep, returnType, freeVariables, isLValue, breakValid, continueValid;
 
-flowtype ExprOrTypeName = decorate {env, returnType};
+flowtype ExprOrTypeName = decorate {env, returnType, breakValid, continueValid};
 
 propagate host, errors, globalDecls, functionDecls, defs, freeVariables on ExprOrTypeName;
 

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Lifted.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Lifted.sv
@@ -3,17 +3,17 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 {--
  - Extensions that want to specify declartions to lift to a global scope
  - do so by forwarding to the host production `injectGlobalDecls` (or one
- - of the corresponding ones for Stmt or BaseTypeExpr.)  
- - 
+ - of the corresponding ones for Stmt or BaseTypeExpr.)
+ -
  - ASTs may contain constructs that cannot be directly translated into C, for
- - example declarations need to be lifted to the proper place. 
- - 
+ - example declarations need to be lifted to the proper place.
+ -
  - A pair of synthesized attributes can be used for this.
  - * `globalDecls`: the list of declarations to lift up
  - * `host`: the tranformed tree containing only proper host productions.
  - An invariant here is that all Decl nodes in the original tree appear in
  - either `globalDecls` or in `host`.  Also, the 'injection' productions
- - defined here should not occur in the host tree.  
+ - defined here should not occur in the host tree.
  -
  - One issue with this is how to generate the correct environment for the
  - 'lifted' tree passed to an injection production.  The behaviour we *want* is
@@ -21,7 +21,7 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
  - of the tree, including the decl which emitted the globalDecls in the first
  - place.  This unfortunately doesn't work, because of a cyclical dependancy in
  - that the env is needed in the first place to figure out the names of the
- - items being injected, which are then used to generate the env.  
+ - items being injected, which are then used to generate the env.
  -
  - Instead, we decorate the new decls at the level of the injection production
  - with an environment only containing the outermost scope in the current env,
@@ -30,7 +30,7 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
  - which inserts them in the outermost scope of the environment.  To ensure
  - that these defs are in scope for the rest of the tree, we must re-add the
  - defs from the globalDecls being passed upward wherever a new scope is opened.
- - 
+ -
  - Some extensions may want to use the same global decl with the same name in
  - multiple places.  To avoid inserting the decl more than once, the new decl
  - must check that it has not already been defined before forwarding to
@@ -46,8 +46,8 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
  - It is also possible for extensions to specify declarations to lift to the
  - current function's outermost scope. This can be done by forwarding to the
  - host production `injectFunctionDeclsDecl`. The same properties discussed
- - above with global scope lifting apply the same to the function scope 
- - lifting, just using the `functionDecls` attribute to track these 
+ - above with global scope lifting apply the same to the function scope
+ - lifting, just using the `functionDecls` attribute to track these
  - declarations.
  -
  - TODO:
@@ -85,13 +85,13 @@ flowtype unfoldedFunctionDecls {decorate} on
 
 {--
  - Wrapper production for a decl that first performs some sort of check for whether something is in
- - the environment before including that decl in the Decls passed to an injection production 
+ - the environment before including that decl in the Decls passed to an injection production
  -}
 abstract production maybeDecl
 top::Decl ::= include::(Boolean ::= Decorated Env) decl::Decl
 {
   top.pp = cat(pp"maybe ", braces(nestlines(2, decl.pp)));
-  
+
   forwards to
     if include(top.env)
     then decl
@@ -103,21 +103,21 @@ abstract production maybeValueDecl
 top::Decl ::= name::String decl::Decl
 {
   top.pp = cat(pp"maybeValue (${text(name)}) ", braces(nestlines(2, decl.pp)));
-  
+
   forwards to maybeDecl(\ env::Decorated Env -> null(lookupValue(name, top.env)), decl);
 }
 abstract production maybeTagDecl
 top::Decl ::= name::String decl::Decl
 {
   top.pp = cat(pp"maybeTag (${text(name)}) ", braces(nestlines(2, decl.pp)));
-  
+
   forwards to maybeDecl(\ env::Decorated Env -> null(lookupTag(name, top.env)), decl);
 }
 abstract production maybeRefIdDecl
 top::Decl ::= name::String decl::Decl
 {
   top.pp = cat(pp"maybeRefId (${text(name)}) ", braces(nestlines(2, decl.pp)));
-  
+
   forwards to maybeDecl(\ env::Decorated Env -> null(lookupRefId(name, top.env)), decl);
 }
 
@@ -127,24 +127,26 @@ top::Expr ::= decls::Decls lifted::Expr
 {
   propagate errors, functionDecls;
   top.pp = pp"injectGlobalDeclsExpr ${braces(nestlines(2, ppImplode(line(), decls.pps)))} (${lifted.pp})";
-  
+
   -- Insert defs from decls at the global scope
   top.defs := globalDefsDef(decls.defs) :: lifted.defs;
 
   -- Note that the invariant over `globalDecls` and `lifted` is maintained.
   top.globalDecls := decls.unfoldedGlobalDecls ++ lifted.globalDecls;
   top.host = lifted.host;
-  
+
   -- Variables corresponing to lifted values are *not* considered free, since they are either bound
   -- here (host tree) or available globally and shouldn't recieve special treatment (lifted tree).
   top.freeVariables := removeDefsFromNames(decls.defs, lifted.freeVariables);
-  
+
   -- Define other attributes to be the same as on lifted
   top.typerep = lifted.typerep;
 
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = nothing();
+  decls.breakValid = false;
+  decls.continueValid = false;
 
   lifted.env = addEnv([globalDefsDef(decls.defs)], top.env);
 
@@ -157,25 +159,27 @@ top::Stmt ::= decls::Decls lifted::Stmt
 {
   propagate errors, functionDecls;
   top.pp = pp"injectGlobalDeclsStmt ${braces(nestlines(2, ppImplode(line(), decls.pps)))} ${braces(nestlines(2, lifted.pp))}";
-  
+
   -- Insert defs from decls at the global scope
   top.defs := globalDefsDef(decls.defs) :: lifted.defs;
 
   -- Note that the invariant over `globalDecls` and `lifted` is maintained.
   top.globalDecls := decls.unfoldedGlobalDecls ++ lifted.globalDecls;
   top.host = lifted.host;
-  
+
   -- Variables corresponing to lifted values are *not* considered free, since they are either bound
   -- here (host tree) or available globally and shouldn't recieve special treatment (lifted tree).
   top.freeVariables := removeDefsFromNames(decls.defs, lifted.freeVariables);
-  
+
   -- Define other attributes to be the same as on lifted
   top.functionDefs := lifted.functionDefs;
-  
+
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = nothing();
-  
+  decls.breakValid = false;
+  decls.continueValid = false;
+
   lifted.env = addEnv([globalDefsDef(decls.defs)], top.env);
 }
 
@@ -185,28 +189,30 @@ top::BaseTypeExpr ::= decls::Decls lifted::BaseTypeExpr
 {
   propagate errors, functionDecls;
   top.pp = pp"injectGlobalDeclsTypeExpr ${braces(nestlines(2, ppImplode(line(), decls.pps)))} (${lifted.pp})";
-  
+
   -- Insert defs from decls at the global scope
   top.defs := globalDefsDef(decls.defs) :: lifted.defs;
 
   -- Note that the invariant over `globalDecls` and `lifted` is maintained.
   top.globalDecls := decls.unfoldedGlobalDecls ++ lifted.globalDecls;
   top.host = lifted.host;
-  
+
   -- Variables corresponing to lifted values are *not* considered free, since they are either bound
   -- here (host tree) or available globally and shouldn't recieve special treatment (lifted tree).
   top.freeVariables := removeDefsFromNames(decls.defs, lifted.freeVariables);
-  
+
   -- Preserve injected decls when transforming to and back from typerep
   top.decls := [injectGlobalDeclsDecl(decls)];
-  
+
   -- Define other attributes to be the same as on lifted
   top.typerep = lifted.typerep;
   top.typeModifier = lifted.typeModifier;
-  
+
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = nothing();
+  decls.breakValid = false;
+  decls.continueValid = false;
 
   lifted.env = addEnv([globalDefsDef(decls.defs)], top.env);
 }
@@ -217,20 +223,22 @@ top::Decl ::= decls::Decls
 {
   propagate errors, functionDecls;
   top.pp = pp"injectGlobalDeclsDecl ${braces(nestlines(2, ppImplode(line(), decls.pps)))}";
-  
+
   -- Insert defs from decls at the global scope
   top.defs := [globalDefsDef(decls.defs)];
 
   -- Note that the invariant over `globalDecls` and `lifted` is maintained.
   top.globalDecls := decls.unfoldedGlobalDecls;
   top.host = edu:umn:cs:melt:ableC:abstractsyntax:host:decls(nilDecl());
-  
+
   -- Define other attributes to be the same as on "lifted" (i.e. nilDecl())
   top.freeVariables := [];
-  
+
   decls.env = globalEnv(top.env);
   decls.isTopLevel = true;
   decls.returnType = nothing();
+  decls.breakValid = false;
+  decls.continueValid = false;
 }
 
 abstract production injectFunctionDeclsDecl
@@ -249,6 +257,8 @@ top::Decl ::= decls::Decls
   decls.env = functionEnv(top.env);
   decls.isTopLevel = false;
   decls.returnType = nothing();
+  decls.breakValid = false;
+  decls.continueValid = false;
 }
 
 {--

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Root.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Root.sv
@@ -18,6 +18,8 @@ top::Root ::= d::GlobalDecls
 --  d.env = addEnv(builtinfunctions:initialEnv;
   d.env = addEnv(builtinfunctions:getInitialEnvDefs(), top.env);
   d.returnType = nothing();
+  d.breakValid = false;
+  d.continueValid = false;
 }
 
 synthesized attribute srcAst::Root;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
@@ -372,7 +372,7 @@ top::Stmt ::=
   top.pp = cat( text("continue"), semi() );
   top.errors := if top.continueValid then []
                 else [err(loc("TODOcontinue",-1,-1,-1,-1,-1,-1), -- TODO: Location
-                  "Continue statement not within a loop")];
+                  "continue statement is in an invalid location")];
   top.globalDecls := [];
   top.functionDecls := [];
   top.defs := [];
@@ -387,7 +387,7 @@ top::Stmt ::=
   top.pp = ppConcat([ text("break"), semi()  ]);
   top.errors := if top.breakValid then []
                 else [err(loc("TODObreak",-1,-1,-1,-1,-1,-1), -- TODO: Location
-                  "Break statement not within a loop or switch statement")];
+                  "break statement is in an invalid location")];
   top.globalDecls := [];
   top.functionDecls := [];
   top.defs := [];

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Stmt.sv
@@ -1,9 +1,19 @@
 grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
 
-nonterminal Stmt with pp, host, errors, globalDecls, functionDecls, defs, env, functionDefs, returnType, freeVariables;
-flowtype Stmt = decorate {env, returnType};
+nonterminal Stmt with pp, host, errors, globalDecls, functionDecls, defs, env,
+  functionDefs, returnType, freeVariables, breakValid, continueValid;
+flowtype Stmt = decorate {env, returnType, breakValid, continueValid};
 
 autocopy attribute returnType :: Maybe<Type>;
+
+{-
+ - These variables track whether a break/continue statement are valid at a
+ - particular place. Per the C standard, a break is valid in the body of a
+ - loop or switch statement and a continue is valid only within the body
+ - of a loop
+ -}
+autocopy attribute breakValid :: Boolean;
+autocopy attribute continueValid :: Boolean;
 
 abstract production nullStmt
 top::Stmt ::=
@@ -20,7 +30,7 @@ top::Stmt ::= h::Stmt  t::Stmt
   top.freeVariables :=
     h.freeVariables ++
     removeDefsFromNames(h.defs, t.freeVariables);
-  
+
   t.env = addEnv(h.defs, top.env);
 }
 
@@ -92,7 +102,7 @@ top::Stmt ::= t::Type n::Name init::Expr
             nilAttribute(),
             justInitializer(exprInitializer(init, location=init.location))),
           nilDeclarator())));
-        
+
 }
 
 abstract production exprStmt
@@ -110,7 +120,7 @@ top::Stmt ::= c::Expr  t::Stmt  e::Stmt
     text("if"), space(), parens(c.pp), line(),
     braces(nestlines(2, t.pp)),
     text(" else "), braces(nestlines(2, e.pp))]);
-  
+
   -- A selection statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. Each associated substatement is also a block whose scope is a strict
   -- subset of the scope of the selection statement.
@@ -120,11 +130,11 @@ top::Stmt ::= c::Expr  t::Stmt  e::Stmt
     c.freeVariables ++
     removeDefsFromNames(c.defs, t.freeVariables) ++
     removeDefsFromNames(c.defs, e.freeVariables);
-  
+
   c.env = openScopeEnv(top.env);
   t.env = addEnv(c.defs, c.env);
   e.env = addEnv(globalDeclsDefs(t.globalDecls) ++ functionDeclsDefs(t.functionDecls), t.env);
-  
+
   top.errors <-
     if c.typerep.defaultFunctionArrayLvalueConversion.isScalarType then []
     else [err(c.location, "If condition must be scalar type, instead it is " ++ showType(c.typerep))];
@@ -143,13 +153,13 @@ abstract production whileStmt
 top::Stmt ::= e::Expr  b::Stmt
 {
   propagate host;
-  top.pp = ppConcat([ text("while"), space(), parens(e.pp), line(), 
+  top.pp = ppConcat([ text("while"), space(), parens(e.pp), line(),
                     braces(nestlines(2, b.pp)) ]);
   top.errors := e.errors ++ b.errors;
   top.globalDecls := e.globalDecls ++ b.globalDecls;
   top.functionDecls := e.functionDecls ++ b.functionDecls;
   top.functionDefs := b.functionDefs;
-  
+
   -- An iteration statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. The loop body is also a block whose scope is a strict subset of the scope
   -- of the iteration statement.
@@ -157,27 +167,30 @@ top::Stmt ::= e::Expr  b::Stmt
   top.freeVariables :=
     e.freeVariables ++
     removeDefsFromNames(e.defs, b.freeVariables);
-  
+
   e.env = openScopeEnv(top.env);
   b.env = addEnv(e.defs, e.env);
 
   top.errors <-
     if e.typerep.defaultFunctionArrayLvalueConversion.isScalarType then []
     else [err(e.location, "While condition must be scalar type, instead it is " ++ showType(e.typerep))];
+
+  b.breakValid = true;
+  b.continueValid = true;
 }
 
 abstract production doStmt
 top::Stmt ::= b::Stmt  e::Expr
 {
   propagate host;
-  top.pp = ppConcat([ text("do"),  line(), 
-                    braces(nestlines(2,b.pp)), line(), 
+  top.pp = ppConcat([ text("do"),  line(),
+                    braces(nestlines(2,b.pp)), line(),
                     text("while"), space(), parens(e.pp), semi()]);
   top.errors := b.errors ++ e.errors;
   top.globalDecls := b.globalDecls ++ e.globalDecls;
   top.functionDecls := b.functionDecls ++ e.functionDecls;
   top.functionDefs := b.functionDefs;
-  
+
   -- An iteration statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. The loop body is also a block whose scope is a strict subset of the scope
   -- of the iteration statement.
@@ -185,27 +198,30 @@ top::Stmt ::= b::Stmt  e::Expr
   top.freeVariables :=
     b.freeVariables ++
     removeDefsFromNames(b.defs, e.freeVariables);
-  
+
   b.env = openScopeEnv(top.env);
   e.env = addEnv(globalDeclsDefs(b.globalDecls) ++ functionDeclsDefs(b.functionDecls), b.env);
 
   top.errors <-
     if e.typerep.defaultFunctionArrayLvalueConversion.isScalarType then []
     else [err(e.location, "Do-while condition must be scalar type, instead it is " ++ showType(e.typerep))];
+
+  b.breakValid = true;
+  b.continueValid = true;
 }
 
 abstract production forStmt
 top::Stmt ::= i::MaybeExpr  c::MaybeExpr  s::MaybeExpr  b::Stmt
 {
   propagate host;
-  top.pp = 
+  top.pp =
     ppConcat([text("for"), parens(ppConcat([i.pp, semi(), space(), c.pp, semi(), space(), s.pp])), line(),
       braces(nestlines(2, b.pp)) ]);
   top.errors := i.errors ++ c.errors ++ s.errors ++ b.errors;
   top.globalDecls := i.globalDecls ++ c.globalDecls ++ s.globalDecls ++ b.globalDecls;
   top.functionDecls := i.functionDecls ++ c.functionDecls ++ s.functionDecls ++ b.functionDecls;
   top.functionDefs := b.functionDefs;
-  
+
   -- An iteration statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. The loop body is also a block whose scope is a strict subset of the scope
   -- of the iteration statement.
@@ -223,7 +239,7 @@ top::Stmt ::= i::MaybeExpr  c::MaybeExpr  s::MaybeExpr  b::Stmt
     removeDefsFromNames(i.defs, c.freeVariables) ++
     removeDefsFromNames(i.defs ++ c.defs, s.freeVariables) ++
     removeDefsFromNames(i.defs ++ c.defs ++ s.defs, b.freeVariables);
-  
+
   i.env = openScopeEnv(top.env);
   c.env = addEnv(i.defs, i.env);
   s.env = addEnv(c.defs, c.env);
@@ -233,19 +249,22 @@ top::Stmt ::= i::MaybeExpr  c::MaybeExpr  s::MaybeExpr  b::Stmt
   top.errors <-
     if cty.defaultFunctionArrayLvalueConversion.isScalarType then []
     else [err(loc("TODOfor1",-1,-1,-1,-1,-1,-1), "For condition must be scalar type, instead it is " ++ showType(cty))]; -- TODO: location
+
+  b.breakValid = true;
+  b.continueValid = true;
 }
 
 abstract production forDeclStmt
 top::Stmt ::= i::Decl  c::MaybeExpr  s::MaybeExpr  b::Stmt
 {
   propagate host;
-  top.pp = ppConcat([ text("for"), space(), parens( ppConcat([ i.pp, space(), c.pp, semi(), space(), s.pp]) ), 
+  top.pp = ppConcat([ text("for"), space(), parens( ppConcat([ i.pp, space(), c.pp, semi(), space(), s.pp]) ),
                     line(), braces(nestlines(2, b.pp)) ]);
   top.errors := i.errors ++ c.errors ++ s.errors ++ b.errors;
   top.globalDecls := i.globalDecls ++ c.globalDecls ++ s.globalDecls ++ b.globalDecls;
   top.functionDecls := i.functionDecls ++ c.functionDecls ++ s.functionDecls ++ b.functionDecls;
   top.functionDefs := b.functionDefs;
-  
+
   -- An iteration statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. The loop body is also a block whose scope is a strict subset of the scope
   -- of the iteration statement.
@@ -263,7 +282,7 @@ top::Stmt ::= i::Decl  c::MaybeExpr  s::MaybeExpr  b::Stmt
     removeDefsFromNames(i.defs, c.freeVariables) ++
     removeDefsFromNames(i.defs ++ c.defs, s.freeVariables) ++
     removeDefsFromNames(i.defs ++ c.defs ++ s.defs, b.freeVariables);
-  
+
   i.env = openScopeEnv(top.env);
   c.env = addEnv(i.defs, i.env);
   s.env = addEnv(c.defs, c.env);
@@ -274,6 +293,9 @@ top::Stmt ::= i::Decl  c::MaybeExpr  s::MaybeExpr  b::Stmt
   top.errors <-
     if cty.defaultFunctionArrayLvalueConversion.isScalarType then []
     else [err(loc("TODOfor2",-1,-1,-1,-1,-1,-1), "For condition must be scalar type, instead it is " ++ showType(cty))]; -- TODO: location
+
+  b.breakValid = true;
+  b.continueValid = true;
 }
 
 abstract production returnStmt
@@ -303,13 +325,13 @@ abstract production switchStmt
 top::Stmt ::= e::Expr  b::Stmt
 {
   propagate host;
-  top.pp = ppConcat([ text("switch"), space(), parens(e.pp),  line(), 
+  top.pp = ppConcat([ text("switch"), space(), parens(e.pp),  line(),
                     braces(nestlines(2, b.pp)) ]);
   top.errors := e.errors ++ b.errors;
   top.globalDecls := e.globalDecls ++ b.globalDecls;
   top.functionDecls := e.functionDecls ++ b.functionDecls;
   top.functionDefs := b.functionDefs;
-  
+
   -- A selection statement is a block whose scope is a strict subset of the scope of its
   -- enclosing block. Each associated substatement is also a block whose scope is a strict
   -- subset of the scope of the selection statement.
@@ -317,13 +339,15 @@ top::Stmt ::= e::Expr  b::Stmt
   top.freeVariables :=
     e.freeVariables ++
     removeDefsFromNames(e.defs, b.freeVariables);
-  
+
   e.env = openScopeEnv(top.env);
   b.env = addEnv(e.defs, e.env);
 
   top.errors <-
     if e.typerep.defaultFunctionArrayLvalueConversion.isIntegerType then []
     else [err(e.location, "Switch expression must have integer type, instead it is " ++ showType(e.typerep))];
+
+  b.breakValid = true;
 }
 
 abstract production gotoStmt
@@ -337,7 +361,7 @@ top::Stmt ::= l::Name
   top.defs := [];
   top.freeVariables := [];
   top.functionDefs := [];
-  
+
   top.errors <- l.labelLookupCheck;
 }
 
@@ -346,7 +370,9 @@ top::Stmt ::=
 {
   propagate host;
   top.pp = cat( text("continue"), semi() );
-  top.errors := [];
+  top.errors := if top.continueValid then []
+                else [err(loc("TODOcontinue",-1,-1,-1,-1,-1,-1), -- TODO: Location
+                  "Continue statement not within a loop")];
   top.globalDecls := [];
   top.functionDecls := [];
   top.defs := [];
@@ -359,7 +385,9 @@ top::Stmt ::=
 {
   propagate host;
   top.pp = ppConcat([ text("break"), semi()  ]);
-  top.errors := [];
+  top.errors := if top.breakValid then []
+                else [err(loc("TODObreak",-1,-1,-1,-1,-1,-1), -- TODO: Location
+                  "Break statement not within a loop or switch statement")];
   top.globalDecls := [];
   top.functionDecls := [];
   top.defs := [];
@@ -378,7 +406,7 @@ top::Stmt ::= l::Name  s::Stmt
   top.defs := s.defs;
   top.freeVariables := s.freeVariables;
   top.functionDefs := s.functionDefs;
-  
+
   top.errors <- l.labelRedeclarationCheck;
   top.functionDefs <- [labelDef(l.name, labelItem(l.location))];
 }
@@ -387,7 +415,7 @@ abstract production caseLabelStmt
 top::Stmt ::= v::Expr  s::Stmt
 {
   propagate host;
-  top.pp = ppConcat([text("case"), space(), v.pp, text(":"), nestlines(2,s.pp)]); 
+  top.pp = ppConcat([text("case"), space(), v.pp, text(":"), nestlines(2,s.pp)]);
   top.errors := v.errors ++ s.errors;
   top.globalDecls := v.globalDecls ++ s.globalDecls;
   top.functionDecls := v.functionDecls ++ s.functionDecls;
@@ -396,7 +424,7 @@ top::Stmt ::= v::Expr  s::Stmt
     v.freeVariables ++
     removeDefsFromNames(v.defs, s.freeVariables);
   top.functionDefs := s.functionDefs; -- ??
-  
+
   s.env = addEnv(v.defs, v.env);
 }
 
@@ -432,7 +460,7 @@ abstract production caseLabelRangeStmt
 top::Stmt ::= l::Expr  u::Expr  s::Stmt
 {
   propagate host;
-  top.pp = ppConcat([text("case"), space(), l.pp, text("..."), u.pp, text(":"), space(),s.pp]); 
+  top.pp = ppConcat([text("case"), space(), l.pp, text("..."), u.pp, text(":"), space(),s.pp]);
   top.errors := l.errors ++ u.errors ++ s.errors;
   top.globalDecls := l.globalDecls ++ u.globalDecls ++ s.globalDecls;
   top.functionDecls := l.functionDecls ++ u.functionDecls ++ s.functionDecls;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
@@ -22,14 +22,14 @@ grammar edu:umn:cs:melt:ableC:abstractsyntax:host;
  -
  - TypeModifierExpr are terminated by "baseTypeExpr" which provides a typerep
  - value that is equal to the Type obtained from the corresponding BaseTypeExpr.
- - 
+ -
  - Invariant: a BaseTypeExpr and its corresponding TypeModifierExpr should have
  - the same environment
  -
  - Since BaseTypeExpr may contain new declarations, another invariant is that
  - extension productions containing a BaseTypeExpr must forward to a tree
  - containing that BaseTypeExpr exactly once.  However, they are free to use
- - directTypeExpr(ty.typerep) as many times as needed.    
+ - directTypeExpr(ty.typerep) as many times as needed.
  -}
 
 autocopy attribute baseType :: Type;
@@ -59,8 +59,10 @@ flowtype decls {decorate} on
 synthesized attribute bty :: BaseTypeExpr;
 synthesized attribute mty :: TypeModifierExpr;
 
-nonterminal TypeName with env, typerep, bty, mty, pp, host, errors, globalDecls, functionDecls, decls, defs, returnType, freeVariables;
-flowtype TypeName = decorate {env, returnType}, bty {}, mty {};
+nonterminal TypeName with env, typerep, bty, mty, pp, host, errors, globalDecls,
+  functionDecls, decls, defs, returnType, freeVariables, breakValid, continueValid;
+flowtype TypeName = decorate {env, returnType, breakValid, continueValid},
+  bty {}, mty {};
 
 abstract production typeName
 top::TypeName ::= bty::BaseTypeExpr  mty::TypeModifierExpr
@@ -85,10 +87,12 @@ top::TypeName ::= bty::BaseTypeExpr  mty::TypeModifierExpr
       -- TODO: Should be lifting decls to the closest scope, not global!
       map(
         \ d::Decl ->
-          decorate d with {env = top.env; returnType = top.returnType; isTopLevel = true;},
+          decorate d with {env = top.env; returnType = top.returnType; isTopLevel = true;
+            breakValid = top.breakValid; continueValid = top.continueValid;},
         -- decorate needed here because of flowtype for decls
         decorate bty.host with {
           env = bty.env; returnType = bty.returnType; givenRefId = bty.givenRefId;
+          breakValid = bty.breakValid; continueValid = bty.continueValid;
         }.decls)
     | nothing() -> []
     end ++ bty.globalDecls ++ mty.globalDecls;
@@ -124,8 +128,11 @@ top::TypeName ::= ty::Decorated TypeName
 {--
  - Corresponds to types obtainable from a TypeSpecifiers.
  -}
-nonterminal BaseTypeExpr with env, typerep, pp, host, errors, globalDecls, functionDecls, typeModifier, decls, defs, givenRefId, returnType, freeVariables;
-flowtype BaseTypeExpr = decorate {env, givenRefId, returnType}, typeModifier {decorate};
+nonterminal BaseTypeExpr with env, typerep, pp, host, errors, globalDecls,
+  functionDecls, typeModifier, decls, defs, givenRefId, returnType, freeVariables,
+  breakValid, continueValid;
+flowtype BaseTypeExpr = decorate {env, givenRefId, returnType, breakValid, continueValid},
+  typeModifier {decorate};
 
 abstract production errorTypeExpr
 top::BaseTypeExpr ::= msg::[Message]
@@ -152,7 +159,7 @@ top::BaseTypeExpr ::= msg::[Message]  ty::BaseTypeExpr
  - This is NOT a host production, since Type should not occur in the host tree.
  - Instead we transform the parameter type into a TypeExpr and return that.
  - Note that directTypeExpr(te.typerep) is not necessarily equivalent to te, since TypeExprs can
- - contain extra information relevant only to the declaration, not to the meaning of the type.  
+ - contain extra information relevant only to the declaration, not to the meaning of the type.
  - However, directTypeExpr(ty).typerep should be the same as ty, and
  - directTypeExpr(te.typerep).host.typerep should be the same as te.typerep.host
  -}
@@ -203,7 +210,7 @@ top::BaseTypeExpr ::= d::[Def]  bty::BaseTypeExpr
   top.typeModifier = bty.typeModifier;
   top.decls := defsDecl(d) :: bty.decls;
   top.defs <- d;
-  
+
   bty.env = addEnv(d, top.env);
 }
 
@@ -218,7 +225,7 @@ top::BaseTypeExpr ::= bty::BaseTypeExpr  mty::TypeModifierExpr
   top.host = fromMaybe(bty.host, mty.modifiedBaseTypeExpr);
   top.typerep = mty.typerep;
   top.typeModifier = mty.host;
-  
+
   mty.env = addEnv(bty.defs, bty.env);
   mty.baseType = bty.typerep;
   mty.typeModifierIn = bty.typeModifier;
@@ -257,7 +264,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
   -- This code is nassssty. TODO. Possibly split enum references to a separate production? This might simplify the logic considerably.
 
   local tags :: [TagItem] = lookupTag(n.name, top.env);
-  
+
   top.typerep =
     case kwd, tags of
     -- It's an enum and we see the declaration.
@@ -270,7 +277,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
     -- Otherwise, error!
     | _, _ -> errorType()
     end;
-  
+
   top.errors <-
     case kwd, tags of
     -- It's an enum and we see the declaration.
@@ -285,9 +292,9 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
     | unionSEU(), refIdTagItem(unionSEU(), rid) :: _ -> []
     | unionSEU(), _ :: _ -> [err(n.location, "Tag " ++ n.name ++ " is not a union")]
     end;
-  
+
   top.typeModifier = baseTypeExpr();
-  
+
   top.decls :=
     if null(lookupTag(n.name, top.env))
     then
@@ -303,7 +310,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
              nothingInitializer()),
            nilDeclarator()))]
     else [];
-  
+
   top.defs <-
     case kwd, tags of
     -- It's an enum and we see the declaration.
@@ -316,7 +323,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
     -- Otherwise, error!
     | _, _ -> []
     end;
-  
+
   q.typeToQualify = top.typerep;
 }
 
@@ -330,7 +337,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  refId::String
   top.typerep = extType(q, refIdExtType(kwd, nothing(), refId));
   top.typeModifier = baseTypeExpr();
   top.decls := [];
-  
+
   q.typeToQualify = top.typerep;
 }
 
@@ -395,8 +402,8 @@ top::BaseTypeExpr ::= q::Qualifiers  name::Name
 {
   propagate host, errors, globalDecls, functionDecls, defs, decls, freeVariables;
   top.pp = ppConcat([terminate(space(), q.pps), name.pp ]);
-  
-  top.typerep = 
+
+  top.typerep =
     noncanonicalType(
       typedefType(
         q, name.name,
@@ -404,7 +411,7 @@ top::BaseTypeExpr ::= q::Qualifiers  name::Name
         then errorType()
         else addQualifiers(q.qualifiers, name.valueItem.typerep)));
   top.typeModifier = baseTypeExpr();
-  
+
   top.errors <- name.valueLookupCheck;
   top.errors <-
     if name.valueItem.isItemType then []
@@ -417,7 +424,7 @@ top::BaseTypeExpr ::= q::Qualifiers  name::Name
  - can only be attatched on declarations.  Thus this production is never actually introduced by
  - concrete syntax, but it can be created when translating a transformed attributed type back to a
  - BaseTypeExpr.  To enable this, we must lift a typedef with the appropriate attributes and refer
- - to that.  
+ - to that.
  -}
 abstract production attributedTypeExpr
 top::BaseTypeExpr ::= attrs::Attributes  bt::BaseTypeExpr
@@ -476,8 +483,12 @@ top::BaseTypeExpr ::= q::Qualifiers  e::ExprOrTypeName
  - Typically, these are just anchored somewhere to obtain the env,
  - and then turn into an environment-independent Type.
  -}
-nonterminal TypeModifierExpr with env, typerep, lpp, rpp, host, modifiedBaseTypeExpr, isFunctionArrayTypeExpr, baseType, typeModifierIn, errors, globalDecls, functionDecls, decls, defs, returnType, freeVariables;
-flowtype TypeModifierExpr = decorate {env, baseType, typeModifierIn, returnType}, modifiedBaseTypeExpr {decorate}, isFunctionArrayTypeExpr {};
+nonterminal TypeModifierExpr with env, typerep, lpp, rpp, host, modifiedBaseTypeExpr,
+  isFunctionArrayTypeExpr, baseType, typeModifierIn, errors, globalDecls,
+  functionDecls, decls, defs, returnType, freeVariables, breakValid, continueValid;
+flowtype TypeModifierExpr = decorate {env, baseType, typeModifierIn, returnType,
+  breakValid, continueValid},
+  modifiedBaseTypeExpr {decorate}, isFunctionArrayTypeExpr {};
 
 synthesized attribute modifiedBaseTypeExpr::Maybe<BaseTypeExpr>;
 synthesized attribute isFunctionArrayTypeExpr::Boolean;
@@ -489,9 +500,9 @@ top::TypeModifierExpr ::=
 }
 
 {--
- - A TypeModifierExpr that corresponds to whatever the base TypeExpr was.  
+ - A TypeModifierExpr that corresponds to whatever the base TypeExpr was.
  - This gets transformed via host to include type modifiers that were included in the base
- - TypeExpr via typeModifierTypeExpr.  
+ - TypeExpr via typeModifierTypeExpr.
  -}
 abstract production baseTypeExpr
 top::TypeModifierExpr ::=
@@ -521,7 +532,7 @@ top::TypeModifierExpr ::= bty::BaseTypeExpr
   top.host = bty.typeModifier; -- top.typeModifierIn discarded
   top.modifiedBaseTypeExpr = just(bty.host);
   top.typerep = bty.typerep;
-  
+
   bty.givenRefId = nothing();
 }
 
@@ -571,14 +582,14 @@ top::TypeModifierExpr ::= element::TypeModifierExpr  indexQualifiers::Qualifiers
 {
   propagate host, errors, globalDecls, functionDecls, defs, decls, freeVariables;
   top.lpp = element.lpp;
-  
+
   top.rpp = cat(brackets(ppConcat([
     terminate(space(), indexQualifiers.pps ++ sizeModifier.pps),
     size.pp
     ])), element.rpp);
-  
+
   top.modifiedBaseTypeExpr = element.modifiedBaseTypeExpr;
-  
+
   top.isFunctionArrayTypeExpr = true;
 
   top.typerep =
@@ -595,13 +606,13 @@ top::TypeModifierExpr ::= element::TypeModifierExpr  indexQualifiers::Qualifiers
 {
   propagate host, errors, globalDecls, functionDecls, defs, decls, freeVariables;
   top.lpp = element.lpp;
-  
+
   top.rpp = cat(brackets(
     ppImplode(space(), indexQualifiers.pps ++ sizeModifier.pps)
     ), element.rpp);
-  
+
   top.modifiedBaseTypeExpr = element.modifiedBaseTypeExpr;
-  
+
   top.isFunctionArrayTypeExpr = true;
 
   top.typerep = arrayType(element.typerep, indexQualifiers, sizeModifier, incompleteArrayType());
@@ -615,25 +626,25 @@ top::TypeModifierExpr ::= result::TypeModifierExpr  args::Parameters  variadic::
   propagate host, errors, globalDecls, functionDecls, defs, decls, freeVariables;
   top.lpp = ppConcat([ result.lpp ]);
 
-  top.rpp = 
+  top.rpp =
     cat(parens(
-      if null(args.pps) 
+      if null(args.pps)
       then text("void")
-      else ppImplode(text(", "), 
-            (if variadic then args.pps ++ [text("...")] else args.pps) 
+      else ppImplode(text(", "),
+            (if variadic then args.pps ++ [text("...")] else args.pps)
            )
      ), result.rpp);
-  
+
   top.modifiedBaseTypeExpr = result.modifiedBaseTypeExpr;
-  
+
   top.isFunctionArrayTypeExpr = true;
-  
-  top.typerep = functionType(result.typerep, 
+
+  top.typerep = functionType(result.typerep,
                              protoFunctionType(args.typereps, variadic), q);
-  
+
   args.env = openScopeEnv(top.env);
   args.position = 0;
-  
+
   q.typeToQualify = top.typerep;
 }
 abstract production functionTypeExprWithoutArgs
@@ -642,11 +653,11 @@ top::TypeModifierExpr ::= result::TypeModifierExpr  ids::[Name]  q::Qualifiers -
   propagate host, errors, globalDecls, functionDecls, defs, decls, freeVariables;
   top.lpp = result.lpp;
   top.rpp = cat( parens(ppImplode(text(", "), map((.pp), ids))), result.rpp );
-  
+
   top.modifiedBaseTypeExpr = result.modifiedBaseTypeExpr;
-  
+
   top.isFunctionArrayTypeExpr = true;
-  
+
   top.typerep = functionType(result.typerep, noProtoFunctionType(), q);
   q.typeToQualify = top.typerep;
 }
@@ -666,8 +677,11 @@ top::TypeModifierExpr ::= wrapped::TypeModifierExpr
 autocopy attribute appendedTypeNames :: TypeNames;
 synthesized attribute appendedTypeNamesRes :: TypeNames;
 
-nonterminal TypeNames with pps, host, env, typereps, count, errors, globalDecls, functionDecls, decls, defs, returnType, freeVariables, appendedTypeNames, appendedTypeNamesRes;
-flowtype TypeNames = decorate {env, returnType}, count {}, appendedTypeNamesRes {appendedTypeNames};
+nonterminal TypeNames with pps, host, env, typereps, count, errors, globalDecls,
+  functionDecls, decls, defs, returnType, freeVariables, appendedTypeNames,
+  appendedTypeNamesRes, breakValid, continueValid;
+flowtype TypeNames = decorate {env, returnType, breakValid, continueValid},
+  count {}, appendedTypeNamesRes {appendedTypeNames};
 
 propagate host, errors, globalDecls, functionDecls, decls, defs, freeVariables on TypeNames;
 
@@ -678,12 +692,12 @@ top::TypeNames ::= h::TypeName t::TypeNames
   top.typereps = h.typerep :: t.typereps;
   top.count = t.count + 1;
   top.appendedTypeNamesRes = consTypeName(h, t.appendedTypeNamesRes);
-  
+
   t.env = addEnv(h.defs, h.env);
 }
 
 abstract production nilTypeName
-top::TypeNames ::= 
+top::TypeNames ::=
 {
   top.pps = [];
   top.typereps = [];

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeQualifiers.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeQualifiers.sv
@@ -141,8 +141,9 @@ top::Qualifier ::=
  - e.g. Function specifiers (inline, _Noreturn)
  -      Alignment specifiers (_Alignas)
  -}
-nonterminal SpecialSpecifier with pp, host, env, returnType, errors, globalDecls, functionDecls, defs;
-flowtype SpecialSpecifier = decorate {env, returnType};
+nonterminal SpecialSpecifier with pp, host, env, returnType, errors, globalDecls,
+  functionDecls, defs, breakValid, continueValid;
+flowtype SpecialSpecifier = decorate {env, returnType, breakValid, continueValid};
 
 propagate host, errors, globalDecls, functionDecls, defs on SpecialSpecifier;
 
@@ -166,8 +167,9 @@ top::SpecialSpecifier ::= e::Expr
   top.pp = ppConcat([text("_Alignas"), parens(e.pp)]);
 }
 
-nonterminal SpecialSpecifiers with pps, host, env, returnType, errors, globalDecls, functionDecls, defs;
-flowtype SpecialSpecifiers = decorate {env, returnType};
+nonterminal SpecialSpecifiers with pps, host, env, returnType, errors,
+  globalDecls, functionDecls, defs, breakValid, continueValid;
+flowtype SpecialSpecifiers = decorate {env, returnType, breakValid, continueValid};
 
 propagate host, errors, globalDecls, functionDecls, defs on SpecialSpecifiers;
 
@@ -182,7 +184,7 @@ top::SpecialSpecifiers ::=
 {
   top.pps = [];
 }
-	
+
 
 function containsQualifier
 Boolean ::= q::Qualifier t::Type

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
@@ -44,6 +44,8 @@ top::host:Expr ::= lhs::host:Expr  deref::Boolean  rhs::host:Name
     else mkAddressOf(lhs, lhs.location);
   preModLhs.env = lhs.env;
   preModLhs.host:returnType = lhs.host:returnType;
+  preModLhs.host:breakValid = lhs.host:breakValid;
+  preModLhs.host:continueValid = lhs.host:continueValid;
 
   local preModDeref :: Boolean = deref || !null(runtimeMods);
 
@@ -96,10 +98,14 @@ top::host:Expr ::= f::host:Expr  a::host:Exprs
   local tmpArgs :: host:Exprs = foldExpr(mkTmpExprsRefs(a, tmpNamePrefix, 0));
   tmpArgs.env = top.env;
   tmpArgs.host:returnType = top.host:returnType;
+  tmpArgs.host:breakValid = top.host:breakValid;
+  tmpArgs.host:continueValid = top.host:continueValid;
 
   local callFunc :: host:Expr = host:callExpr(f, tmpArgs, location=top.location);
   callFunc.env = top.env;
   callFunc.host:returnType = top.host:returnType;
+  callFunc.host:breakValid = top.host:breakValid;
+  callFunc.host:continueValid = top.host:continueValid;
 
   local tmpResultDecl :: host:Stmt =
     mkDecl(
@@ -116,6 +122,8 @@ top::host:Expr ::= f::host:Expr  a::host:Exprs
     );
   tmpResultRef.env = top.env;
   tmpResultRef.host:returnType = top.host:returnType;
+  tmpResultRef.host:breakValid = top.host:breakValid;
+  tmpResultRef.host:continueValid = top.host:continueValid;
 
   local injExpr :: host:Expr =
     host:stmtExpr(


### PR DESCRIPTION
Resolves #184 (I got around to this sooner than I expected)

Introduces two new attributes `breakValid` and `continueValid` which are boolean and represent whether a break or continue statement, respectively, are valid in the current location in the tree. These are autocopy attributes and we set them to true in places in the tree where they become valid (a loop body or the body of a switch for a break).  These attributes occur on the same nonterminals as `returnType` because (as far as I can tell) there are pretty much no places a return is allowed where a break/continue isn't (as long as its within an appropriate construct). 
I made the errors more general than actually specifically saying that break/continue are only valid in a loop (or switch) since with extensions there may be more places they can be placed (or some types of loops where they aren't allowed). 

Also, this requires updates to a number of extensions; I've done my best to make sensible choices for these attribute values (mostly mimicking how `returnType` was handled), but it might be worth having someone at some point go through and figure out what we should really do, since this change is rather powerful--we can now prohibit break/continue statements from certain blocks of code which I imagine could be useful in the Halide extension for example.

Also, I don't think there's an issue for this already, but we need some way to get locations onto at least return/break/continue statements so that they can report sensible error locations (though would this be fixed by origin tracking?)