### PR TITLE
Renaming IO types/functions

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
@@ -44,7 +44,7 @@ top::Name ::= n::String
     | _ -> nothing()
     end;
   top.tagHasForwardDcl = refIdIfOld.isJust;
-  top.tagRefId = fromMaybe(toString(genInt()), refIdIfOld);
+  top.tagRefId = fromMaybe(toString(genIntT()), refIdIfOld);
   
   local labdcls :: [LabelItem] = lookupLabel(n, top.controlStmtContext);
   top.labelRedeclarationCheck =

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
@@ -304,7 +304,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
          top,
          consDeclarator(
            declarator(
-             name("_unused_" ++ toString(genInt()), location=builtinLoc("host")),
+             name("_unused_" ++ toString(genIntT()), location=builtinLoc("host")),
              baseTypeExpr(),
              nilAttribute(),
              nothingInitializer()),
@@ -432,7 +432,7 @@ top::BaseTypeExpr ::= attrs::Attributes  bt::BaseTypeExpr
   top.pp = cat(ppAttributes(attrs), bt.pp);
 
   local liftedName::Name =
-    name(s"_attributedType_${toString(genInt())}", location=builtinLoc("host"));
+    name(s"_attributedType_${toString(genIntT())}", location=builtinLoc("host"));
   forwards to
     -- TODO: We can currently only lift to the global level, but this should be lifted to the closest scope
     injectGlobalDeclsTypeExpr(

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
@@ -91,7 +91,7 @@ top::host:Expr ::= f::host:Expr  a::host:Exprs
   production attribute postInsertions :: [(host:Stmt ::= Decorated host:Exprs  Decorated host:Expr)] with ++;
   postInsertions := case top.env, top.host:controlStmtContext.host:returnType of emptyEnv_i(), nothing() -> [] | _, _ -> [] end;
 
-  local tmpNamePrefix :: String = "_tmp" ++ toString(genInt());
+  local tmpNamePrefix :: String = "_tmp" ++ toString(genIntT());
 
   local tmpArgs :: host:Exprs = foldExpr(mkTmpExprsRefs(a, tmpNamePrefix, 0));
   tmpArgs.env = top.env;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Mods.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Mods.sv
@@ -32,9 +32,9 @@ top::LhsOrRhsRuntimeMods ::=
 function applyLhsRhsMods
 Pair<Expr Expr> ::= l::[LhsOrRhsRuntimeMod]  lhs::Decorated Expr  rhs::Decorated Expr
 {
-  local tmpLhsName :: String = "_tmpLhs" ++ toString(genInt());
+  local tmpLhsName :: String = "_tmpLhs" ++ toString(genIntT());
   local tmpLhs :: Expr = declRefExpr(name(tmpLhsName, location=lhs.location), location=lhs.location);
-  local tmpRhsName :: String = "_tmpRhs" ++ toString(genInt());
+  local tmpRhsName :: String = "_tmpRhs" ++ toString(genIntT());
   local tmpRhs :: Expr = declRefExpr(name(tmpRhsName, location=rhs.location), location=rhs.location);
 
   local mods :: LhsOrRhsRuntimeMods = foldr(consLhsOrRhsRuntimeMod, nilLhsOrRhsRuntimeMod(), l);
@@ -108,7 +108,7 @@ top::RuntimeMods ::=
 function applyMods
 Expr ::= l::[RuntimeMod] e::Decorated Expr
 {
-  local tmpName :: String = "_tmp" ++ toString(genInt());
+  local tmpName :: String = "_tmp" ++ toString(genIntT());
   local tmpDecl :: Stmt = mkDecl(tmpName, e.typerep, new(e), e.location);
 
   local mods :: RuntimeMods = foldr(consRuntimeMod, nilRuntimeMod(), l);

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/Expr.sv
@@ -124,7 +124,7 @@ top::host:Expr ::= ty::host:TypeName  init::host:InitList
       host:decTypeName(ty),
       init,
       location=top.location);
-  local tmpName::host:Name = host:name("_res_" ++ toString(genInt()), location=top.location);
+  local tmpName::host:Name = host:name("_res_" ++ toString(genIntT()), location=top.location);
   forwards to
     case t.objectInitProd of
     | just(prod) ->

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/ExprBinOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/ExprBinOps.sv
@@ -1555,7 +1555,7 @@ top::host:Expr ::= lhs::host:Expr  rhs::host:Expr
 function mkEqRewriteExpr
 host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Location
 {
-  local tmpName::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
+  local tmpName::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
   -- ({auto ${tmpName} = &${lhs}; *${tmpName} = *${tmpName} ${baseOp} ${rhs};})
   return
     host:stmtExpr(
@@ -1572,8 +1572,8 @@ host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Locat
 function mkTmpBinOpExpr
 host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Location
 {
-  local tmpName1::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
-  local tmpName2::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
+  local tmpName1::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
+  local tmpName2::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
   -- ({auto ${tmpName1} = ${lhs}; auto ${tmpName2} = rhs; ${tmpName1} ${baseOp} ${tmpName2};})
   return
     host:stmtExpr(

--- a/grammars/edu.umn.cs.melt.ableC/compiler/Main.sv
+++ b/grammars/edu.umn.cs.melt.ableC/compiler/Main.sv
@@ -4,7 +4,7 @@ import edu:umn:cs:melt:ableC:host;
 import edu:umn:cs:melt:ableC:drivers:parseAndPrint;
 
 function main
-IOVal<Integer> ::= args::[String] io_in::IO
+IOVal<Integer> ::= args::[String] io_in::IOToken
 {
   return driver(args, io_in, ablecParser);
 }

--- a/grammars/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/grammars/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -9,11 +9,11 @@ imports silver:langutil:pp;
 import edu:umn:cs:melt:ableC:abstractsyntax:env ; --only env, emptyEnv;
 
 function driver
-IOVal<Integer> ::= args::[String] ioIn::IO 
+IOVal<Integer> ::= args::[String] ioIn::IOToken 
   theParser::(ParseResult<cst:Root>::=String String)
 {
   local fileName :: String = head(args);
-  local splitFileName :: Pair<String String> = splitFileNameAndExtension(fileName);
+  local splitFileName :: Pair<String String> = splitFileNameAndExtensionT(fileName);
   local baseFileName :: String = splitFileName.fst;
   local skipCpp :: Boolean = contains("--skip-cpp", args);
   local cppFileName :: String = if skipCpp then fileName else baseFileName ++ ".gen_cpp";
@@ -27,27 +27,27 @@ IOVal<Integer> ::= args::[String] ioIn::IO
   local cppCmd :: String = "gcc -E -x c -D _POSIX_C_SOURCE -std=gnu1x -I . " ++ cppOptions;
   local fullCppCmd :: String = cppCmd ++ " \"" ++ fileName ++ "\" > " ++ cppFileName;
   
-  local result::IOMonad<Integer> = do {
+  local result::IO<Integer> = do {
     if null(args) then do {
-      printM("Usage: [ableC invocation] [file name] [c preprocessor arguments]\n");
+      print("Usage: [ableC invocation] [file name] [c preprocessor arguments]\n");
       return 5;
     } else do {
-      isF::Boolean <- isFileM(fileName);
+      isF::Boolean <- isFile(fileName);
       if !isF then do {
-        printM("File \"" ++ fileName ++ "\" not found.\n");
+        print("File \"" ++ fileName ++ "\" not found.\n");
         return 1;
       } else do {
         when_(contains("--show-cpp", args),
-          printM("CPP command: " ++ fullCppCmd ++ "\n"));
-        mkCppFile::Integer <- if skipCpp then returnIO(0) else systemM(fullCppCmd);
+          print("CPP command: " ++ fullCppCmd ++ "\n"));
+        mkCppFile::Integer <- if skipCpp then returnIO(0) else system(fullCppCmd);
         if mkCppFile != 0 then do {
-          printM("CPP call failed: " ++ fullCppCmd ++ "\n");
+          print("CPP call failed: " ++ fullCppCmd ++ "\n");
           return 3;
         } else do {
-          text :: String <- readFileM(cppFileName);
+          text :: String <- readFile(cppFileName);
           let result :: ParseResult<cst:Root> = theParser(text, cppFileName);
           if !result.parseSuccess then do {
-            printM(result.parseErrors ++ "\n");
+            print(result.parseErrors ++ "\n");
             return 2;
           } else do {
             let comp :: Decorated abs:Compilation =
@@ -55,22 +55,22 @@ IOVal<Integer> ::= args::[String] ioIn::IO
                 env = addEnv( map(xcArgDef, xcArgs) , emptyEnv() );
               };
             if contains("--show-ast", args) then do {
-              printM(substitute("edu:umn:cs:melt:", "", hackUnparse(comp.abs:srcAst)) ++ "\n");
+              print(substitute("edu:umn:cs:melt:", "", hackUnparse(comp.abs:srcAst)) ++ "\n");
               return 0;
             } else if contains("--show-host-ast", args) then do {
-              printM(substitute("edu:umn:cs:melt:", "", hackUnparse(comp.abs:hostAst)) ++ "\n");
+              print(substitute("edu:umn:cs:melt:", "", hackUnparse(comp.abs:hostAst)) ++ "\n");
               return 0;
             } else if contains("--show-pp", args) then do {
-              printM(show(100, comp.abs:srcPP) ++ "\n");
+              print(show(100, comp.abs:srcPP) ++ "\n");
               return 0;
             } else if contains("--show-host-pp", args) then do {
-              printM(show(100, comp.abs:hostPP) ++ "\n");
+              print(show(100, comp.abs:hostPP) ++ "\n");
               return 0;
             } else do {
               unless(null(comp.errors),
-                printM(messagesToString(comp.errors) ++ "\n"));
+                print(messagesToString(comp.errors) ++ "\n"));
               when_(contains("--force-trans", args) || !containsErrors(comp.errors, false),
-                writeFileM(ppFileName, show(80, comp.abs:finalPP)));
+                writeFile(ppFileName, show(80, comp.abs:finalPP)));
               return if containsErrors(comp.errors, true) then 4 else 0;
             };
           };


### PR DESCRIPTION
# Changes
Issue #461.  Refactoring of the token-based `IO` type to `IOToken`. All `IOToken` function names which conflict with those in the 'new' `IO` type (prev. `IOMonad`) are now suffixed with `T`. Function names previously in `IOMonad` (now `IO`) which were suffixed with `M`, now have the `M` removed.

# Documentation
Other than matching refactoring in already existing comments, no documentation was introduced in the refactoring effort.