### PR TITLE
Refactoring IOToken functions - removing unnecessary T suffixes

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Name.sv
@@ -44,7 +44,7 @@ top::Name ::= n::String
     | _ -> nothing()
     end;
   top.tagHasForwardDcl = refIdIfOld.isJust;
-  top.tagRefId = fromMaybe(toString(genIntT()), refIdIfOld);
+  top.tagRefId = fromMaybe(toString(genInt()), refIdIfOld);
   
   local labdcls :: [LabelItem] = lookupLabel(n, top.controlStmtContext);
   top.labelRedeclarationCheck =

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
@@ -304,7 +304,7 @@ top::BaseTypeExpr ::= q::Qualifiers  kwd::StructOrEnumOrUnion  n::Name
          top,
          consDeclarator(
            declarator(
-             name("_unused_" ++ toString(genIntT()), location=builtinLoc("host")),
+             name("_unused_" ++ toString(genInt()), location=builtinLoc("host")),
              baseTypeExpr(),
              nilAttribute(),
              nothingInitializer()),
@@ -432,7 +432,7 @@ top::BaseTypeExpr ::= attrs::Attributes  bt::BaseTypeExpr
   top.pp = cat(ppAttributes(attrs), bt.pp);
 
   local liftedName::Name =
-    name(s"_attributedType_${toString(genIntT())}", location=builtinLoc("host"));
+    name(s"_attributedType_${toString(genInt())}", location=builtinLoc("host"));
   forwards to
     -- TODO: We can currently only lift to the global level, but this should be lifted to the closest scope
     injectGlobalDeclsTypeExpr(

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Expr.sv
@@ -91,7 +91,7 @@ top::host:Expr ::= f::host:Expr  a::host:Exprs
   production attribute postInsertions :: [(host:Stmt ::= Decorated host:Exprs  Decorated host:Expr)] with ++;
   postInsertions := case top.env, top.host:controlStmtContext.host:returnType of emptyEnv_i(), nothing() -> [] | _, _ -> [] end;
 
-  local tmpNamePrefix :: String = "_tmp" ++ toString(genIntT());
+  local tmpNamePrefix :: String = "_tmp" ++ toString(genInt());
 
   local tmpArgs :: host:Exprs = foldExpr(mkTmpExprsRefs(a, tmpNamePrefix, 0));
   tmpArgs.env = top.env;

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Mods.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/injectable/Mods.sv
@@ -32,9 +32,9 @@ top::LhsOrRhsRuntimeMods ::=
 function applyLhsRhsMods
 Pair<Expr Expr> ::= l::[LhsOrRhsRuntimeMod]  lhs::Decorated Expr  rhs::Decorated Expr
 {
-  local tmpLhsName :: String = "_tmpLhs" ++ toString(genIntT());
+  local tmpLhsName :: String = "_tmpLhs" ++ toString(genInt());
   local tmpLhs :: Expr = declRefExpr(name(tmpLhsName, location=lhs.location), location=lhs.location);
-  local tmpRhsName :: String = "_tmpRhs" ++ toString(genIntT());
+  local tmpRhsName :: String = "_tmpRhs" ++ toString(genInt());
   local tmpRhs :: Expr = declRefExpr(name(tmpRhsName, location=rhs.location), location=rhs.location);
 
   local mods :: LhsOrRhsRuntimeMods = foldr(consLhsOrRhsRuntimeMod, nilLhsOrRhsRuntimeMod(), l);
@@ -108,7 +108,7 @@ top::RuntimeMods ::=
 function applyMods
 Expr ::= l::[RuntimeMod] e::Decorated Expr
 {
-  local tmpName :: String = "_tmp" ++ toString(genIntT());
+  local tmpName :: String = "_tmp" ++ toString(genInt());
   local tmpDecl :: Stmt = mkDecl(tmpName, e.typerep, new(e), e.location);
 
   local mods :: RuntimeMods = foldr(consRuntimeMod, nilRuntimeMod(), l);

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/Expr.sv
@@ -124,7 +124,7 @@ top::host:Expr ::= ty::host:TypeName  init::host:InitList
       host:decTypeName(ty),
       init,
       location=top.location);
-  local tmpName::host:Name = host:name("_res_" ++ toString(genIntT()), location=top.location);
+  local tmpName::host:Name = host:name("_res_" ++ toString(genInt()), location=top.location);
   forwards to
     case t.objectInitProd of
     | just(prod) ->

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/ExprBinOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/overloadable/ExprBinOps.sv
@@ -1555,7 +1555,7 @@ top::host:Expr ::= lhs::host:Expr  rhs::host:Expr
 function mkEqRewriteExpr
 host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Location
 {
-  local tmpName::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
+  local tmpName::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
   -- ({auto ${tmpName} = &${lhs}; *${tmpName} = *${tmpName} ${baseOp} ${rhs};})
   return
     host:stmtExpr(
@@ -1572,8 +1572,8 @@ host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Locat
 function mkTmpBinOpExpr
 host:Expr ::= baseOpProd::BinaryProd  lhs::host:Expr  rhs::host:Expr  loc::Location
 {
-  local tmpName1::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
-  local tmpName2::host:Name = host:name("_tmp" ++ toString(genIntT()), location=loc);
+  local tmpName1::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
+  local tmpName2::host:Name = host:name("_tmp" ++ toString(genInt()), location=loc);
   -- ({auto ${tmpName1} = ${lhs}; auto ${tmpName2} = rhs; ${tmpName1} ${baseOp} ${tmpName2};})
   return
     host:stmtExpr(

--- a/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
+++ b/grammars/edu.umn.cs.melt.ableC/drivers/compile/Driver.sv
@@ -56,7 +56,7 @@ IOVal<Integer> ::= args::[String] ioIn::IOToken
   theParser::(ParseResult<cst:Root>::=String String)
 {
   local fileName :: String = head(args);
-  local splitFileName :: Pair<String String> = splitFileNameAndExtensionT(fileName);
+  local splitFileName :: Pair<String String> = splitFileNameAndExtension(fileName);
   local baseFileName :: String = splitFileName.fst;
   local skipCpp :: Boolean = contains("--skip-cpp", args);
   local cppFileName :: String = if skipCpp then fileName else baseFileName ++ ".i";

--- a/grammars/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
+++ b/grammars/edu.umn.cs.melt.ableC/drivers/parseAndPrint/Driver.sv
@@ -13,7 +13,7 @@ IOVal<Integer> ::= args::[String] ioIn::IOToken
   theParser::(ParseResult<cst:Root>::=String String)
 {
   local fileName :: String = head(args);
-  local splitFileName :: Pair<String String> = splitFileNameAndExtensionT(fileName);
+  local splitFileName :: Pair<String String> = splitFileNameAndExtension(fileName);
   local baseFileName :: String = splitFileName.fst;
   local skipCpp :: Boolean = contains("--skip-cpp", args);
   local cppFileName :: String = if skipCpp then fileName else baseFileName ++ ".gen_cpp";


### PR DESCRIPTION
# Changes
Simply removing the T suffix from IO functions corresponding to those in Silver.

# Documentation
None added.
