### PR TITLE
Adding some semantic token lexer classes

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/ConcreteSyntax.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/ConcreteSyntax.sv
@@ -15,6 +15,9 @@ exports edu:umn:cs:melt:ableC:concretesyntax:gcc_exts;
 -- concrete syntax, no further semantic analysis is made.
 imports silver:langutil only ast, errors, err, wrn;
 
+-- Lexer classes for semantic token highlighting
+imports silver:langutil:lsp as lsp;
+
 -- errors it prefixed with ast, to avoid any name clashes.
 imports edu:umn:cs:melt:ableC:abstractsyntax:host as ast;
 

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -32,7 +32,7 @@ temp_imp_ide_font font_equal color(71, 71, 141) bold;
 {--
  - Comments and whitespace
  -}
-lexer class Comment extends AbleC, font = font_comments;
+lexer class Comment extends {AbleC, lsp:Comment}, font = font_comments;
 
 -- The C preprocessor strips these for us, but handle them here for completeness.
 ignore terminal LineComment_t
@@ -68,7 +68,7 @@ terminal TypeName_t   /[A-Za-z_\$][A-Za-z_0-9\$]*/ lexer classes {Type, Identifi
 {--
  - Literals
  -}
-lexer class NumericLiteral extends AbleC;
+lexer class NumericLiteral extends {AbleC, lsp:Number};
 
 -- Begins with 1-9 or is just 0 alone
 terminal DecConstant_t /((0)|([1-9][0-9]*))/ lexer classes {NumericLiteral};
@@ -143,7 +143,7 @@ terminal HexFloatConstantFloat_t /0[xX](([a-fA-F0-9]+[.]?)|([a-fA-F0-9]*[.][a-fA
 terminal HexFloatConstantLongDouble_t /0[xX](([a-fA-F0-9]+[.]?)|([a-fA-F0-9]*[.][a-fA-F0-9]+))([Pp][-+]?[0-9]+)[Ll]/ lexer classes {NumericLiteral};
 
 
-lexer class StringLiteral extends AbleC, font = font_string;
+lexer class StringLiteral extends {AbleC, lsp:String_}, font = font_string;
 
 terminal StringConstant_t      /["]([^"\\]|[\\].)*["]/ lexer classes {StringLiteral};
 terminal StringConstantU8_t  /u8["]([^"\\]|[\\].)*["]/ lexer classes {StringLiteral};
@@ -169,12 +169,12 @@ terminal CharConstantUBig_t /U[']([^']|[\\].)[']/ lexer classes {StringLiteral};
  - Note that Reserved doesn't extend AbleC, other host languages/extensions using AbleC
  - as a DSL may define terminals in this lexer class.
  -}
-lexer class Keyword extends AbleC, font = font_all;
+lexer class Keyword extends {AbleC, lsp:Keyword}, font = font_all;
 lexer class Reserved;
 
 
 -- types
-lexer class Type extends AbleC, font = font_type;
+lexer class Type extends {AbleC, lsp:Type}, font = font_type;
 
 terminal Char_t     'char'     lexer classes {Type, Reserved};
 terminal Double_t   'double'   lexer classes {Type, Reserved};
@@ -195,19 +195,19 @@ terminal Struct_t 'struct' lexer classes {Keyword, Reserved};
 terminal Union_t  'union'  lexer classes {Keyword, Reserved};
 
 -- Qualifiers
-terminal Const_t    'const'    lexer classes {Keyword, Reserved};
-terminal Volatile_t 'volatile' lexer classes {Keyword, Reserved};
-terminal Restrict_t 'restrict' lexer classes {Keyword, Reserved}; -- c99
+terminal Const_t    'const'    lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Volatile_t 'volatile' lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Restrict_t 'restrict' lexer classes {Keyword, Reserved, lsp:Modification}; -- c99
 
 -- Function specifiers
-terminal Inline_t   'inline'   lexer classes {Keyword, Reserved}; -- c99
+terminal Inline_t   'inline'   lexer classes {Keyword, Reserved, lsp:Modification}; -- c99
 
 -- Storage class specifiers
-terminal Auto_t     'auto'     lexer classes {Keyword, Reserved};
-terminal Extern_t   'extern'   lexer classes {Keyword, Reserved};
-terminal Register_t 'register' lexer classes {Keyword, Reserved};
-terminal Static_t   'static'   lexer classes {Keyword, Reserved};
-terminal Typedef_t  'typedef'  lexer classes {Keyword, Reserved};
+terminal Auto_t     'auto'     lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Extern_t   'extern'   lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Register_t 'register' lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Static_t   'static'   lexer classes {Keyword, Reserved, lsp:Modification};
+terminal Typedef_t  'typedef'  lexer classes {Keyword, Reserved, lsp:Modification};
 
 -- Statement keywords
 terminal Break_t    'break'    lexer classes {Keyword, Reserved};
@@ -257,7 +257,7 @@ disambiguate LCurly_t, TypeLCurly_t {
   pluck if allowStructEnumUnionDecl then TypeLCurly_t else LCurly_t;
 }
 
-lexer class Operator extends AbleC, font = font_special_symbol;
+lexer class Operator extends {AbleC, lsp:Operator}, font = font_special_symbol;
 
 terminal Question_t    '?'    lexer classes {Operator};
 terminal Colon_t       ':'    lexer classes {Operator};


### PR DESCRIPTION
There's a lot more that could be done here using parser attributes to categorize identifiers.  But this adds basic comments, keywords, operators and literals, at least, so they show up in silver-ableC specifications.  