### PR TITLE
Fix the character constant regexes to support the escapes in C11.

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/Terminals.sv
@@ -140,10 +140,10 @@ terminal StringConstantL_t    /L["]([^"\\]|[\\].)*["]/ lexer classes {StringLite
 terminal StringConstantU_t    /u["]([^"\\]|[\\].)*["]/ lexer classes {StringLiteral};
 terminal StringConstantUBig_t /U["]([^"\\]|[\\].)*["]/ lexer classes {StringLiteral};
 
-terminal CharConstant_t      /[']([^']|[\\].)[']/ lexer classes {StringLiteral};
-terminal CharConstantL_t    /L[']([^']|[\\].)[']/ lexer classes {StringLiteral};
-terminal CharConstantU_t    /u[']([^']|[\\].)[']/ lexer classes {StringLiteral};
-terminal CharConstantUBig_t /U[']([^']|[\\].)[']/ lexer classes {StringLiteral};
+terminal CharConstant_t     /[']([^'\\]|[\\](['"?\\abfnrtv]|[0-7]+|x[0-9A-Fa-f]+|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]))[']/ lexer classes {StringLiteral};
+terminal CharConstantL_t    /L[']([^'\\]|[\\](['"?\\abfnrtv]|[0-7]+|x[0-9A-Fa-f]+|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]))[']/ lexer classes {StringLiteral};
+terminal CharConstantU_t    /u[']([^'\\]|[\\](['"?\\abfnrtv]|[0-7]+|x[0-9A-Fa-f]+|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]))[']/ lexer classes {StringLiteral};
+terminal CharConstantUBig_t /U[']([^'\\]|[\\](['"?\\abfnrtv]|[0-7]+|x[0-9A-Fa-f]+|u[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]|U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]))[']/ lexer classes {StringLiteral};
 
 
 {--


### PR DESCRIPTION
Can we get this in before the release?

Also, what's the deal with needing `[\\]`? Without it, the regex doesn't match anything, but this feeeeeeels like a workaround for something awful.

(As an aside, the complexity of this regex is making me wish for a more verbose but more readable DSL we compile to terminal regexes...)