### PR TITLE
Adds env to bash shebangs, set -euo pipefail, and fix shellcheck warnings.

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 export GRAMMAR_PATH=
 
@@ -8,5 +9,4 @@ export SILVER_GEN=generated
 # Need to bump up the heap space to run the MWDA:
 export SVJVM_FLAGS="-Xmx6G -Xss25m"
 
-silver -o ableC.jar -I grammars $@ edu:umn:cs:melt:ableC:compiler
-
+silver -o ableC.jar -I grammars "$@" edu:umn:cs:melt:ableC:compiler

--- a/deep-clean
+++ b/deep-clean
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 # find by default never follows symlinks, so this should be relatively safe:
 find . -name "*~" -delete
@@ -13,5 +14,5 @@ find testing/ -name "*.o" -delete
 find testing/ -name "*.jar" -delete
 find testing/ -name "a.out" -delete
 
-rm -f *.jar
+rm -f -- *.jar
 rm -rf generated/

--- a/mda-test
+++ b/mda-test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Run the MDA test for the silver extension for constructing ableC ASTs.
 
@@ -9,4 +10,4 @@ export GRAMMAR_PATH=ableC.jar:grammars
 mkdir -p generated
 export SILVER_GEN=generated
 
-silver --dont-translate $@ edu:umn:cs:melt:ableC:silverconstruction:mda_test
+silver --dont-translate "$@" edu:umn:cs:melt:ableC:silverconstruction:mda_test

--- a/testing/build-test-artifact
+++ b/testing/build-test-artifact
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 export ANT_OPTS="-Xss8M -Xmx4000M"
 export SILVER_GEN=../generated
@@ -20,7 +21,5 @@ if [[ ! -f "../ableC.jar" ]]; then
   exit 1
 fi
 
-
-$SV $SVARGS $@ -o ableC.jar edu:umn:cs:melt:ableC:testing && $SVTHEN || exit 1
-
-
+# shellcheck disable=SC2086
+$SV $SVARGS "$@" -o ableC.jar edu:umn:cs:melt:ableC:testing && $SVTHEN || exit 1

--- a/testing/disable-test
+++ b/testing/disable-test
@@ -1,3 +1,3 @@
-#!/bin/bash
-
-mv $1 $1.disabled
+#!/usr/bin/env bash
+set -euo pipefail
+mv "$1" "$1.disabled"

--- a/testing/enable-test
+++ b/testing/enable-test
@@ -1,3 +1,3 @@
-#!/bin/bash
-
-mv $1.disabled $1
+#!/usr/bin/env bash
+set -euo pipefail
+mv "$1.disabled" "$1"

--- a/testing/open-broken-test
+++ b/testing/open-broken-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-gedit $1 ${1/.c/.gen_cpp} ${1/.c/.cpp_errs} ${1/.c/.errs}
-
+"${EDITOR:-gedit}" "$1" "${1/.c/.gen_cpp}" "${1/.c/.cpp_errs}" "${1/.c/.errs}"

--- a/testing/print-parse-errors
+++ b/testing/print-parse-errors
@@ -1,18 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -uo pipefail
 
+readarray -td '' files < <(find . -name "*.errs" -print0)
 
-FILES=`find . -name "*.errs"`
-
-for file in $FILES; do
+for file in "${files[@]}"; do
   # remove the trailing .err from the file name
   cfile=${file/.errs/.c}
   # get the number of the real character index from a parse error message
-  realcharacterindex=`cat $file | grep "index:" | awk '{ print $7 }' | cut -d\) -f1`
+  realcharacterindex=$(grep "index:" "$file" | awk '{ print $7 }' | cut -d\) -f1)
   # well, maybe there wasn't a parse error message?
   if [ -n "$realcharacterindex" ]; then
     # tail -c+1 starts at the beginning of the file. *sigh* add one to fix its behavior
-    fortail=$(($realcharacterindex + 1))
-    printf "%65s at %5d \t " "$cfile" $realcharacterindex
+    fortail=$((realcharacterindex + 1))
+    printf "%65s at %5d \t " "$cfile" "$realcharacterindex"
     #echo -n "$cfile    at $realcharacterindex"
     #echo -ne "\t"
     # we need to look this char index up in the pre-processed file, not the original
@@ -21,7 +21,7 @@ for file in $FILES; do
     # too early (before munching layout), eat layout.
     # sed command N appends next line onto current input buffer, so we can remove one
     # \n from it in addition to some spaces or tabs
-    tail --byte=+$fortail $gencpp | sed -e 'N;s/^[\ \n\t\r]*//' | head -n 1 | head -c 50 | tr '\n' ' '
+    tail --byte=+$fortail "$gencpp" | sed -e 'N;s/^[\ \n\t\r]*//' | head -n 1 | head -c 50 | tr '\n' ' '
     echo ""
     #echo "-----"
   fi

--- a/testing/print-semantic-errors
+++ b/testing/print-semantic-errors
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-
-FILES=`find . -name "*.errs"`
+readarray -td '' files < <(find . -name "*.errs" -print0)
 
 if [ "$1" == "" ]; then
   # strip off the file, line, column, and just print what errors appeared, somewhere
-  grep -v "Error at line\|CPP call\|^ " $FILES | cut -d: -f5- | sort | uniq
+  grep -v "Error at line\|CPP call\|^ " "${files[@]}" | cut -d: -f5- | sort | uniq
 else
-  grep "$1" $FILES
+  grep "$1" "${files[@]}"
 fi
 

--- a/testing/runTests
+++ b/testing/runTests
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 shopt -s extglob globstar
 
 export LANG=C  # Disable localization to force deterministic glob ordering
@@ -16,7 +16,7 @@ java -Xss8M -jar ableC.jar tests/**/neutral/!(*.pp_out).c | tee expected-results
 
 cd expected-results
 
-set -ve
+set -x
 
 diff positive positive.out
 diff negative negative.out

--- a/testing/update-expected-results
+++ b/testing/update-expected-results
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
 
 cd expected-results/
 

--- a/tools/builtins/build
+++ b/tools/builtins/build
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
-silver -o builtins.jar -I ../../grammars $@ edu:umn:cs:melt:ableC:tools:builtins
+silver -o builtins.jar -I ../../grammars "$@" edu:umn:cs:melt:ableC:tools:builtins

--- a/tools/builtins/generate
+++ b/tools/builtins/generate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euxo pipefail
 java -jar builtins.jar BuiltinsX86.def > ../../grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedIntrinsics.sv
 java -jar builtins.jar Builtins.def > ../../grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv


### PR DESCRIPTION
testing/print-parse-errors is the only file set -e was not added too -- I'm not sure if the grep inside the loop is intended to be allowed to fail or not.