### PR TITLE
Implements __builtin(_dynamic)_object_size, describes reasons for ignoring builtins

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
@@ -1135,10 +1135,10 @@ d <- [valueDef("__builtin_extend_pointer", builtinFunctionValueItem( {-  unsigne
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_object_size", builtinFunctionValueItem( {-  signed int(const void * , signed int) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
-    unevaluatedFunctionHandler))];
+    unevaluatedBuiltinFunctionHandler))];
 d <- [valueDef("__builtin_dynamic_object_size", builtinFunctionValueItem( {-  signed int(const void * , signed int) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
-    unevaluatedFunctionHandler))];
+    unevaluatedBuiltinFunctionHandler))];
 d <- [valueDef("__builtin___memcpy_chk", builtinFunctionValueItem( {-  void * (void * , const void * , signed int, signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
@@ -19,11 +19,11 @@ d <- [valueDef("__builtin_copysign", builtinFunctionValueItem( {-  double(double
 d <- [valueDef("__builtin_copysignf", builtinFunctionValueItem( {-  float(float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_copysignf16 on line 116
+-- Ignored __builtin_copysignf16 on line 116: TODO: h type
 d <- [valueDef("__builtin_copysignl", builtinFunctionValueItem( {-  long double(long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_copysignf128 on line 118
+-- Ignored __builtin_copysignf128 on line 118: TODO: LLd type
 d <- [valueDef("__builtin_fabs", builtinFunctionValueItem( {-  double(double) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), realType(doubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -33,15 +33,15 @@ d <- [valueDef("__builtin_fabsf", builtinFunctionValueItem( {-  float(float) -}
 d <- [valueDef("__builtin_fabsl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fabsf16 on line 122
--- Ignored __builtin_fabsf128 on line 123
+-- Ignored __builtin_fabsf16 on line 122: TODO: h type
+-- Ignored __builtin_fabsf128 on line 123: TODO: LLd type
 d <- [valueDef("__builtin_fmod", builtinFunctionValueItem( {-  double(double, double) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), realType(doubleType())), builtinType(nilQualifier(), realType(doubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_fmodf", builtinFunctionValueItem( {-  float(float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fmodf16 on line 126
+-- Ignored __builtin_fmodf16 on line 126: TODO: h type
 d <- [valueDef("__builtin_fmodl", builtinFunctionValueItem( {-  long double(long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -63,7 +63,7 @@ d <- [valueDef("__builtin_huge_valf", builtinFunctionValueItem( {-  float(void) 
 d <- [valueDef("__builtin_huge_vall", builtinFunctionValueItem( {-  long double(void) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_huge_valf128 on line 134
+-- Ignored __builtin_huge_valf128 on line 134: TODO: LLd type
 d <- [valueDef("__builtin_inf", builtinFunctionValueItem( {-  double(void) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -73,7 +73,7 @@ d <- [valueDef("__builtin_inff", builtinFunctionValueItem( {-  float(void) -}
 d <- [valueDef("__builtin_infl", builtinFunctionValueItem( {-  long double(void) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_inff128 on line 138
+-- Ignored __builtin_inff128 on line 138: TODO: LLd type
 d <- [valueDef("__builtin_labs", builtinFunctionValueItem( {-  signed long(signed long) -}
     functionType(builtinType(nilQualifier(), signedType(longType())), protoFunctionType([builtinType(nilQualifier(), signedType(longType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -107,7 +107,7 @@ d <- [valueDef("__builtin_nanf", builtinFunctionValueItem( {-  float(const char 
 d <- [valueDef("__builtin_nanl", builtinFunctionValueItem( {-  long double(const char * ) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_nanf128 on line 150
+-- Ignored __builtin_nanf128 on line 150: TODO: LLd type
 d <- [valueDef("__builtin_nans", builtinFunctionValueItem( {-  double(const char * ) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -117,7 +117,7 @@ d <- [valueDef("__builtin_nansf", builtinFunctionValueItem( {-  float(const char
 d <- [valueDef("__builtin_nansl", builtinFunctionValueItem( {-  long double(const char * ) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_nansf128 on line 154
+-- Ignored __builtin_nansf128 on line 154: TODO: LLd type
 d <- [valueDef("__builtin_powi", builtinFunctionValueItem( {-  double(double, signed int) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), realType(doubleType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -133,7 +133,7 @@ d <- [valueDef("__builtin_pow", builtinFunctionValueItem( {-  double(double, dou
 d <- [valueDef("__builtin_powf", builtinFunctionValueItem( {-  float(float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_powf16 on line 160
+-- Ignored __builtin_powf16 on line 160: TODO: h type
 d <- [valueDef("__builtin_powl", builtinFunctionValueItem( {-  long double(long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -206,7 +206,7 @@ d <- [valueDef("__builtin_ceil", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_ceilf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_ceilf16 on line 187
+-- Ignored __builtin_ceilf16 on line 187: TODO: h type
 d <- [valueDef("__builtin_ceill", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -216,7 +216,7 @@ d <- [valueDef("__builtin_cos", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_cosf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_cosf16 on line 191
+-- Ignored __builtin_cosf16 on line 191: TODO: h type
 d <- [valueDef("__builtin_cosh", builtinFunctionValueItem( {-  double(double) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), realType(doubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -253,7 +253,7 @@ d <- [valueDef("__builtin_exp", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_expf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_expf16 on line 204
+-- Ignored __builtin_expf16 on line 204: TODO: h type
 d <- [valueDef("__builtin_expl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -263,7 +263,7 @@ d <- [valueDef("__builtin_exp2", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_exp2f", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_exp2f16 on line 208
+-- Ignored __builtin_exp2f16 on line 208: TODO: h type
 d <- [valueDef("__builtin_exp2l", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -291,7 +291,7 @@ d <- [valueDef("__builtin_floor", builtinFunctionValueItem( {-  double(double) -
 d <- [valueDef("__builtin_floorf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_floorf16 on line 218
+-- Ignored __builtin_floorf16 on line 218: TODO: h type
 d <- [valueDef("__builtin_floorl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -301,7 +301,7 @@ d <- [valueDef("__builtin_fma", builtinFunctionValueItem( {-  double(double, dou
 d <- [valueDef("__builtin_fmaf", builtinFunctionValueItem( {-  float(float, float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fmaf16 on line 222
+-- Ignored __builtin_fmaf16 on line 222: TODO: h type
 d <- [valueDef("__builtin_fmal", builtinFunctionValueItem( {-  long double(long double, long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -311,7 +311,7 @@ d <- [valueDef("__builtin_fmax", builtinFunctionValueItem( {-  double(double, do
 d <- [valueDef("__builtin_fmaxf", builtinFunctionValueItem( {-  float(float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fmaxf16 on line 226
+-- Ignored __builtin_fmaxf16 on line 226: TODO: h type
 d <- [valueDef("__builtin_fmaxl", builtinFunctionValueItem( {-  long double(long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -321,7 +321,7 @@ d <- [valueDef("__builtin_fmin", builtinFunctionValueItem( {-  double(double, do
 d <- [valueDef("__builtin_fminf", builtinFunctionValueItem( {-  float(float, float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType())), builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fminf16 on line 230
+-- Ignored __builtin_fminf16 on line 230: TODO: h type
 d <- [valueDef("__builtin_fminl", builtinFunctionValueItem( {-  long double(long double, long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType())), builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -379,7 +379,7 @@ d <- [valueDef("__builtin_log10", builtinFunctionValueItem( {-  double(double) -
 d <- [valueDef("__builtin_log10f", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_log10f16 on line 250
+-- Ignored __builtin_log10f16 on line 250: TODO: h type
 d <- [valueDef("__builtin_log10l", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -398,7 +398,7 @@ d <- [valueDef("__builtin_log2", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_log2f", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_log2f16 on line 257
+-- Ignored __builtin_log2f16 on line 257: TODO: h type
 d <- [valueDef("__builtin_log2l", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -414,7 +414,7 @@ d <- [valueDef("__builtin_logbl", builtinFunctionValueItem( {-  long double(long
 d <- [valueDef("__builtin_logf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_logf16 on line 263
+-- Ignored __builtin_logf16 on line 263: TODO: h type
 d <- [valueDef("__builtin_logl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -487,7 +487,7 @@ d <- [valueDef("__builtin_rint", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_rintf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_rintf16 on line 288
+-- Ignored __builtin_rintf16 on line 288: TODO: h type
 d <- [valueDef("__builtin_rintl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -497,7 +497,7 @@ d <- [valueDef("__builtin_round", builtinFunctionValueItem( {-  double(double) -
 d <- [valueDef("__builtin_roundf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_roundf16 on line 292
+-- Ignored __builtin_roundf16 on line 292: TODO: h type
 d <- [valueDef("__builtin_roundl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -525,7 +525,7 @@ d <- [valueDef("__builtin_sin", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_sinf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_sinf16 on line 302
+-- Ignored __builtin_sinf16 on line 302: TODO: h type
 d <- [valueDef("__builtin_sinh", builtinFunctionValueItem( {-  double(double) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), realType(doubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -544,7 +544,7 @@ d <- [valueDef("__builtin_sqrt", builtinFunctionValueItem( {-  double(double) -}
 d <- [valueDef("__builtin_sqrtf", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_sqrtf16 on line 309
+-- Ignored __builtin_sqrtf16 on line 309: TODO: h type
 d <- [valueDef("__builtin_sqrtl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -584,7 +584,7 @@ d <- [valueDef("__builtin_truncf", builtinFunctionValueItem( {-  float(float) -}
 d <- [valueDef("__builtin_truncl", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_truncf16 on line 323
+-- Ignored __builtin_truncf16 on line 323: TODO: h type
 d <- [valueDef("__builtin_cabs", builtinFunctionValueItem( {-  double(_Complex double) -}
     functionType(builtinType(nilQualifier(), realType(doubleType())), protoFunctionType([builtinType(nilQualifier(), complexType(doubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -834,7 +834,7 @@ d <- [valueDef("__builtin_canonicalize", builtinFunctionValueItem( {-  double(do
 d <- [valueDef("__builtin_canonicalizef", builtinFunctionValueItem( {-  float(float) -}
     functionType(builtinType(nilQualifier(), realType(floatType())), protoFunctionType([builtinType(nilQualifier(), realType(floatType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_canonicalizef16 on line 417
+-- Ignored __builtin_canonicalizef16 on line 417: TODO: h type
 d <- [valueDef("__builtin_canonicalizel", builtinFunctionValueItem( {-  long double(long double) -}
     functionType(builtinType(nilQualifier(), realType(longdoubleType())), protoFunctionType([builtinType(nilQualifier(), realType(longdoubleType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -943,11 +943,11 @@ d <- [valueDef("__builtin_rotateright32", builtinFunctionValueItem( {-  unsigned
 d <- [valueDef("__builtin_rotateright64", builtinFunctionValueItem( {-  unsigned long long(unsigned long long, unsigned long long) -}
     functionType(builtinType(nilQualifier(), unsignedType(longlongType())), protoFunctionType([builtinType(nilQualifier(), unsignedType(longlongType())), builtinType(nilQualifier(), unsignedType(longlongType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_constant_p on line 467
--- Ignored __builtin_classify_type on line 468
--- Ignored __builtin___CFStringMakeConstantString on line 469
--- Ignored __builtin___NSStringMakeConstantString on line 470
--- Ignored __builtin_va_start on line 471
+-- Ignored __builtin_constant_p on line 467: needs custom type-checking logic
+-- Ignored __builtin_classify_type on line 468: needs custom type-checking logic
+-- Ignored __builtin___CFStringMakeConstantString on line 469: TODO: F type
+-- Ignored __builtin___NSStringMakeConstantString on line 470: TODO: F type
+-- Ignored __builtin_va_start on line 471: needs custom type-checking logic
 d <- [valueDef("__builtin_va_end", builtinFunctionValueItem( {-  void(void * ) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -969,7 +969,7 @@ d <- [valueDef("__builtin_bcopy", builtinFunctionValueItem( {-  void(void * , vo
 d <- [valueDef("__builtin_bzero", builtinFunctionValueItem( {-  void(void * , signed int) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_fprintf on line 479
+-- Ignored __builtin_fprintf on line 479: TODO: P type
 d <- [valueDef("__builtin_memchr", builtinFunctionValueItem( {-  void * (const void * , signed int, signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1111,7 +1111,7 @@ d <- [valueDef("__builtin_vsnprintf", builtinFunctionValueItem( {-  signed int(c
 d <- [valueDef("__builtin_thread_pointer", builtinFunctionValueItem( {-  void * (void) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_launder on line 527
+-- Ignored __builtin_launder on line 527: needs custom type-checking logic
 d <- [valueDef("__builtin_is_constant_evaluated", builtinFunctionValueItem( {-  _Bool(void) -}
     functionType(builtinType(nilQualifier(), boolType()), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1133,8 +1133,12 @@ d <- [valueDef("__builtin_dwarf_sp_column", builtinFunctionValueItem( {-  unsign
 d <- [valueDef("__builtin_extend_pointer", builtinFunctionValueItem( {-  unsigned long long(void * ) -}
     functionType(builtinType(nilQualifier(), unsignedType(longlongType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_object_size on line 539
--- Ignored __builtin_dynamic_object_size on line 540
+d <- [valueDef("__builtin_object_size", builtinFunctionValueItem( {-  signed int(const void * , signed int) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
+    unevaluatedFunctionHandler))];
+d <- [valueDef("__builtin_dynamic_object_size", builtinFunctionValueItem( {-  signed int(const void * , signed int) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
+    unevaluatedFunctionHandler))];
 d <- [valueDef("__builtin___memcpy_chk", builtinFunctionValueItem( {-  void * (void * , const void * , signed int, signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1186,11 +1190,11 @@ d <- [valueDef("__builtin___vsnprintf_chk", builtinFunctionValueItem( {-  signed
 d <- [valueDef("__builtin___vsprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, const char * , void) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin___fprintf_chk on line 558
+-- Ignored __builtin___fprintf_chk on line 558: TODO: P type
 d <- [valueDef("__builtin___printf_chk", builtinFunctionValueItem( {-  signed int(signed int, const char * , ...) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], true), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin___vfprintf_chk on line 560
+-- Ignored __builtin___vfprintf_chk on line 560: TODO: P type
 d <- [valueDef("__builtin___vprintf_chk", builtinFunctionValueItem( {-  signed int(signed int, const char * , void) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1215,128 +1219,128 @@ d <- [valueDef("__builtin_debugtrap", builtinFunctionValueItem( {-  void(void) -
 d <- [valueDef("__builtin_unreachable", builtinFunctionValueItem( {-  void(void) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_shufflevector on line 570
--- Ignored __builtin_convertvector on line 571
+-- Ignored __builtin_shufflevector on line 570: needs custom type-checking logic
+-- Ignored __builtin_convertvector on line 571: needs custom type-checking logic
 d <- [valueDef("__builtin_alloca", builtinFunctionValueItem( {-  void * (signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_alloca_with_align", builtinFunctionValueItem( {-  void * (signed int, signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_call_with_static_chain on line 574
--- Ignored __sync_fetch_and_add on line 584
--- Ignored __sync_fetch_and_add_1 on line 585
--- Ignored __sync_fetch_and_add_2 on line 586
--- Ignored __sync_fetch_and_add_4 on line 587
--- Ignored __sync_fetch_and_add_8 on line 588
--- Ignored __sync_fetch_and_add_16 on line 589
--- Ignored __sync_fetch_and_sub on line 591
--- Ignored __sync_fetch_and_sub_1 on line 592
--- Ignored __sync_fetch_and_sub_2 on line 593
--- Ignored __sync_fetch_and_sub_4 on line 594
--- Ignored __sync_fetch_and_sub_8 on line 595
--- Ignored __sync_fetch_and_sub_16 on line 596
--- Ignored __sync_fetch_and_or on line 598
--- Ignored __sync_fetch_and_or_1 on line 599
--- Ignored __sync_fetch_and_or_2 on line 600
--- Ignored __sync_fetch_and_or_4 on line 601
--- Ignored __sync_fetch_and_or_8 on line 602
--- Ignored __sync_fetch_and_or_16 on line 603
--- Ignored __sync_fetch_and_and on line 605
--- Ignored __sync_fetch_and_and_1 on line 606
--- Ignored __sync_fetch_and_and_2 on line 607
--- Ignored __sync_fetch_and_and_4 on line 608
--- Ignored __sync_fetch_and_and_8 on line 609
--- Ignored __sync_fetch_and_and_16 on line 610
--- Ignored __sync_fetch_and_xor on line 612
--- Ignored __sync_fetch_and_xor_1 on line 613
--- Ignored __sync_fetch_and_xor_2 on line 614
--- Ignored __sync_fetch_and_xor_4 on line 615
--- Ignored __sync_fetch_and_xor_8 on line 616
--- Ignored __sync_fetch_and_xor_16 on line 617
--- Ignored __sync_fetch_and_nand on line 619
--- Ignored __sync_fetch_and_nand_1 on line 620
--- Ignored __sync_fetch_and_nand_2 on line 621
--- Ignored __sync_fetch_and_nand_4 on line 622
--- Ignored __sync_fetch_and_nand_8 on line 623
--- Ignored __sync_fetch_and_nand_16 on line 624
--- Ignored __sync_add_and_fetch on line 626
--- Ignored __sync_add_and_fetch_1 on line 627
--- Ignored __sync_add_and_fetch_2 on line 628
--- Ignored __sync_add_and_fetch_4 on line 629
--- Ignored __sync_add_and_fetch_8 on line 630
--- Ignored __sync_add_and_fetch_16 on line 631
--- Ignored __sync_sub_and_fetch on line 633
--- Ignored __sync_sub_and_fetch_1 on line 634
--- Ignored __sync_sub_and_fetch_2 on line 635
--- Ignored __sync_sub_and_fetch_4 on line 636
--- Ignored __sync_sub_and_fetch_8 on line 637
--- Ignored __sync_sub_and_fetch_16 on line 638
--- Ignored __sync_or_and_fetch on line 640
--- Ignored __sync_or_and_fetch_1 on line 641
--- Ignored __sync_or_and_fetch_2 on line 642
--- Ignored __sync_or_and_fetch_4 on line 643
--- Ignored __sync_or_and_fetch_8 on line 644
--- Ignored __sync_or_and_fetch_16 on line 645
--- Ignored __sync_and_and_fetch on line 647
--- Ignored __sync_and_and_fetch_1 on line 648
--- Ignored __sync_and_and_fetch_2 on line 649
--- Ignored __sync_and_and_fetch_4 on line 650
--- Ignored __sync_and_and_fetch_8 on line 651
--- Ignored __sync_and_and_fetch_16 on line 652
--- Ignored __sync_xor_and_fetch on line 654
--- Ignored __sync_xor_and_fetch_1 on line 655
--- Ignored __sync_xor_and_fetch_2 on line 656
--- Ignored __sync_xor_and_fetch_4 on line 657
--- Ignored __sync_xor_and_fetch_8 on line 658
--- Ignored __sync_xor_and_fetch_16 on line 659
--- Ignored __sync_nand_and_fetch on line 661
--- Ignored __sync_nand_and_fetch_1 on line 662
--- Ignored __sync_nand_and_fetch_2 on line 663
--- Ignored __sync_nand_and_fetch_4 on line 664
--- Ignored __sync_nand_and_fetch_8 on line 665
--- Ignored __sync_nand_and_fetch_16 on line 666
--- Ignored __sync_bool_compare_and_swap on line 668
--- Ignored __sync_bool_compare_and_swap_1 on line 669
--- Ignored __sync_bool_compare_and_swap_2 on line 670
--- Ignored __sync_bool_compare_and_swap_4 on line 671
--- Ignored __sync_bool_compare_and_swap_8 on line 672
--- Ignored __sync_bool_compare_and_swap_16 on line 673
--- Ignored __sync_val_compare_and_swap on line 675
--- Ignored __sync_val_compare_and_swap_1 on line 676
--- Ignored __sync_val_compare_and_swap_2 on line 677
--- Ignored __sync_val_compare_and_swap_4 on line 678
--- Ignored __sync_val_compare_and_swap_8 on line 679
--- Ignored __sync_val_compare_and_swap_16 on line 680
--- Ignored __sync_lock_test_and_set on line 682
--- Ignored __sync_lock_test_and_set_1 on line 683
--- Ignored __sync_lock_test_and_set_2 on line 684
--- Ignored __sync_lock_test_and_set_4 on line 685
--- Ignored __sync_lock_test_and_set_8 on line 686
--- Ignored __sync_lock_test_and_set_16 on line 687
--- Ignored __sync_lock_release on line 689
--- Ignored __sync_lock_release_1 on line 690
--- Ignored __sync_lock_release_2 on line 691
--- Ignored __sync_lock_release_4 on line 692
--- Ignored __sync_lock_release_8 on line 693
--- Ignored __sync_lock_release_16 on line 694
--- Ignored __sync_swap on line 696
--- Ignored __sync_swap_1 on line 697
--- Ignored __sync_swap_2 on line 698
--- Ignored __sync_swap_4 on line 699
--- Ignored __sync_swap_8 on line 700
--- Ignored __sync_swap_16 on line 701
--- Ignored __c11_atomic_init on line 710
--- Ignored __c11_atomic_load on line 711
--- Ignored __c11_atomic_store on line 712
--- Ignored __c11_atomic_exchange on line 713
--- Ignored __c11_atomic_compare_exchange_strong on line 714
--- Ignored __c11_atomic_compare_exchange_weak on line 715
--- Ignored __c11_atomic_fetch_add on line 716
--- Ignored __c11_atomic_fetch_sub on line 717
--- Ignored __c11_atomic_fetch_and on line 718
--- Ignored __c11_atomic_fetch_or on line 719
--- Ignored __c11_atomic_fetch_xor on line 720
+-- Ignored __builtin_call_with_static_chain on line 574: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add on line 584: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add_1 on line 585: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add_2 on line 586: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add_4 on line 587: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add_8 on line 588: needs custom type-checking logic
+-- Ignored __sync_fetch_and_add_16 on line 589: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub on line 591: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub_1 on line 592: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub_2 on line 593: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub_4 on line 594: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub_8 on line 595: needs custom type-checking logic
+-- Ignored __sync_fetch_and_sub_16 on line 596: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or on line 598: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or_1 on line 599: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or_2 on line 600: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or_4 on line 601: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or_8 on line 602: needs custom type-checking logic
+-- Ignored __sync_fetch_and_or_16 on line 603: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and on line 605: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and_1 on line 606: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and_2 on line 607: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and_4 on line 608: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and_8 on line 609: needs custom type-checking logic
+-- Ignored __sync_fetch_and_and_16 on line 610: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor on line 612: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor_1 on line 613: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor_2 on line 614: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor_4 on line 615: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor_8 on line 616: needs custom type-checking logic
+-- Ignored __sync_fetch_and_xor_16 on line 617: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand on line 619: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand_1 on line 620: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand_2 on line 621: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand_4 on line 622: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand_8 on line 623: needs custom type-checking logic
+-- Ignored __sync_fetch_and_nand_16 on line 624: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch on line 626: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch_1 on line 627: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch_2 on line 628: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch_4 on line 629: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch_8 on line 630: needs custom type-checking logic
+-- Ignored __sync_add_and_fetch_16 on line 631: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch on line 633: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch_1 on line 634: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch_2 on line 635: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch_4 on line 636: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch_8 on line 637: needs custom type-checking logic
+-- Ignored __sync_sub_and_fetch_16 on line 638: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch on line 640: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch_1 on line 641: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch_2 on line 642: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch_4 on line 643: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch_8 on line 644: needs custom type-checking logic
+-- Ignored __sync_or_and_fetch_16 on line 645: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch on line 647: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch_1 on line 648: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch_2 on line 649: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch_4 on line 650: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch_8 on line 651: needs custom type-checking logic
+-- Ignored __sync_and_and_fetch_16 on line 652: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch on line 654: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch_1 on line 655: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch_2 on line 656: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch_4 on line 657: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch_8 on line 658: needs custom type-checking logic
+-- Ignored __sync_xor_and_fetch_16 on line 659: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch on line 661: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch_1 on line 662: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch_2 on line 663: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch_4 on line 664: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch_8 on line 665: needs custom type-checking logic
+-- Ignored __sync_nand_and_fetch_16 on line 666: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap on line 668: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap_1 on line 669: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap_2 on line 670: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap_4 on line 671: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap_8 on line 672: needs custom type-checking logic
+-- Ignored __sync_bool_compare_and_swap_16 on line 673: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap on line 675: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap_1 on line 676: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap_2 on line 677: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap_4 on line 678: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap_8 on line 679: needs custom type-checking logic
+-- Ignored __sync_val_compare_and_swap_16 on line 680: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set on line 682: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set_1 on line 683: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set_2 on line 684: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set_4 on line 685: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set_8 on line 686: needs custom type-checking logic
+-- Ignored __sync_lock_test_and_set_16 on line 687: needs custom type-checking logic
+-- Ignored __sync_lock_release on line 689: needs custom type-checking logic
+-- Ignored __sync_lock_release_1 on line 690: needs custom type-checking logic
+-- Ignored __sync_lock_release_2 on line 691: needs custom type-checking logic
+-- Ignored __sync_lock_release_4 on line 692: needs custom type-checking logic
+-- Ignored __sync_lock_release_8 on line 693: needs custom type-checking logic
+-- Ignored __sync_lock_release_16 on line 694: needs custom type-checking logic
+-- Ignored __sync_swap on line 696: needs custom type-checking logic
+-- Ignored __sync_swap_1 on line 697: needs custom type-checking logic
+-- Ignored __sync_swap_2 on line 698: needs custom type-checking logic
+-- Ignored __sync_swap_4 on line 699: needs custom type-checking logic
+-- Ignored __sync_swap_8 on line 700: needs custom type-checking logic
+-- Ignored __sync_swap_16 on line 701: needs custom type-checking logic
+-- Ignored __c11_atomic_init on line 710: needs custom type-checking logic
+-- Ignored __c11_atomic_load on line 711: needs custom type-checking logic
+-- Ignored __c11_atomic_store on line 712: needs custom type-checking logic
+-- Ignored __c11_atomic_exchange on line 713: needs custom type-checking logic
+-- Ignored __c11_atomic_compare_exchange_strong on line 714: needs custom type-checking logic
+-- Ignored __c11_atomic_compare_exchange_weak on line 715: needs custom type-checking logic
+-- Ignored __c11_atomic_fetch_add on line 716: needs custom type-checking logic
+-- Ignored __c11_atomic_fetch_sub on line 717: needs custom type-checking logic
+-- Ignored __c11_atomic_fetch_and on line 718: needs custom type-checking logic
+-- Ignored __c11_atomic_fetch_or on line 719: needs custom type-checking logic
+-- Ignored __c11_atomic_fetch_xor on line 720: needs custom type-checking logic
 d <- [valueDef("__c11_atomic_thread_fence", builtinFunctionValueItem( {-  void(signed int) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1346,26 +1350,26 @@ d <- [valueDef("__c11_atomic_signal_fence", builtinFunctionValueItem( {-  void(s
 d <- [valueDef("__c11_atomic_is_lock_free", builtinFunctionValueItem( {-  signed int(signed int) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __atomic_load on line 726
--- Ignored __atomic_load_n on line 727
--- Ignored __atomic_store on line 728
--- Ignored __atomic_store_n on line 729
--- Ignored __atomic_exchange on line 730
--- Ignored __atomic_exchange_n on line 731
--- Ignored __atomic_compare_exchange on line 732
--- Ignored __atomic_compare_exchange_n on line 733
--- Ignored __atomic_fetch_add on line 734
--- Ignored __atomic_fetch_sub on line 735
--- Ignored __atomic_fetch_and on line 736
--- Ignored __atomic_fetch_or on line 737
--- Ignored __atomic_fetch_xor on line 738
--- Ignored __atomic_fetch_nand on line 739
--- Ignored __atomic_add_fetch on line 740
--- Ignored __atomic_sub_fetch on line 741
--- Ignored __atomic_and_fetch on line 742
--- Ignored __atomic_or_fetch on line 743
--- Ignored __atomic_xor_fetch on line 744
--- Ignored __atomic_nand_fetch on line 745
+-- Ignored __atomic_load on line 726: needs custom type-checking logic
+-- Ignored __atomic_load_n on line 727: needs custom type-checking logic
+-- Ignored __atomic_store on line 728: needs custom type-checking logic
+-- Ignored __atomic_store_n on line 729: needs custom type-checking logic
+-- Ignored __atomic_exchange on line 730: needs custom type-checking logic
+-- Ignored __atomic_exchange_n on line 731: needs custom type-checking logic
+-- Ignored __atomic_compare_exchange on line 732: needs custom type-checking logic
+-- Ignored __atomic_compare_exchange_n on line 733: needs custom type-checking logic
+-- Ignored __atomic_fetch_add on line 734: needs custom type-checking logic
+-- Ignored __atomic_fetch_sub on line 735: needs custom type-checking logic
+-- Ignored __atomic_fetch_and on line 736: needs custom type-checking logic
+-- Ignored __atomic_fetch_or on line 737: needs custom type-checking logic
+-- Ignored __atomic_fetch_xor on line 738: needs custom type-checking logic
+-- Ignored __atomic_fetch_nand on line 739: needs custom type-checking logic
+-- Ignored __atomic_add_fetch on line 740: needs custom type-checking logic
+-- Ignored __atomic_sub_fetch on line 741: needs custom type-checking logic
+-- Ignored __atomic_and_fetch on line 742: needs custom type-checking logic
+-- Ignored __atomic_or_fetch on line 743: needs custom type-checking logic
+-- Ignored __atomic_xor_fetch on line 744: needs custom type-checking logic
+-- Ignored __atomic_nand_fetch on line 745: needs custom type-checking logic
 d <- [valueDef("__atomic_test_and_set", builtinFunctionValueItem( {-  _Bool(volatile void * , signed int) -}
     functionType(builtinType(nilQualifier(), boolType()), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1384,21 +1388,21 @@ d <- [valueDef("__atomic_always_lock_free", builtinFunctionValueItem( {-  signed
 d <- [valueDef("__atomic_is_lock_free", builtinFunctionValueItem( {-  signed int(signed int, const volatile void * ) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), consQualifier(volatileQualifier(), nilQualifier())), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __opencl_atomic_init on line 754
--- Ignored __opencl_atomic_load on line 755
--- Ignored __opencl_atomic_store on line 756
--- Ignored __opencl_atomic_exchange on line 757
--- Ignored __opencl_atomic_compare_exchange_strong on line 758
--- Ignored __opencl_atomic_compare_exchange_weak on line 759
--- Ignored __opencl_atomic_fetch_add on line 760
--- Ignored __opencl_atomic_fetch_sub on line 761
--- Ignored __opencl_atomic_fetch_and on line 762
--- Ignored __opencl_atomic_fetch_or on line 763
--- Ignored __opencl_atomic_fetch_xor on line 764
--- Ignored __opencl_atomic_fetch_min on line 765
--- Ignored __opencl_atomic_fetch_max on line 766
--- Ignored __atomic_fetch_min on line 769
--- Ignored __atomic_fetch_max on line 770
+-- Ignored __opencl_atomic_init on line 754: needs custom type-checking logic
+-- Ignored __opencl_atomic_load on line 755: needs custom type-checking logic
+-- Ignored __opencl_atomic_store on line 756: needs custom type-checking logic
+-- Ignored __opencl_atomic_exchange on line 757: needs custom type-checking logic
+-- Ignored __opencl_atomic_compare_exchange_strong on line 758: needs custom type-checking logic
+-- Ignored __opencl_atomic_compare_exchange_weak on line 759: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_add on line 760: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_sub on line 761: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_and on line 762: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_or on line 763: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_xor on line 764: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_min on line 765: needs custom type-checking logic
+-- Ignored __opencl_atomic_fetch_max on line 766: needs custom type-checking logic
+-- Ignored __atomic_fetch_min on line 769: needs custom type-checking logic
+-- Ignored __atomic_fetch_max on line 770: needs custom type-checking logic
 d <- [valueDef("__sync_synchronize", builtinFunctionValueItem( {-  void(void) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1432,10 +1436,10 @@ d <- [valueDef("__annotation", builtinFunctionValueItem( {-  const signed int * 
 d <- [valueDef("__assume", builtinFunctionValueItem( {-  void(_Bool) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), boolType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _bittest on line 791
--- Ignored _bittestandcomplement on line 792
--- Ignored _bittestandreset on line 793
--- Ignored _bittestandset on line 794
+-- Ignored _bittest on line 791: TODO: Ni type
+-- Ignored _bittestandcomplement on line 792: TODO: Ni type
+-- Ignored _bittestandreset on line 793: TODO: Ni type
+-- Ignored _bittestandset on line 794: TODO: Ni type
 d <- [valueDef("_bittest64", builtinFunctionValueItem( {-  unsigned char(const signed long long * , signed long long) -}
     functionType(builtinType(nilQualifier(), unsignedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(longlongType()))), builtinType(nilQualifier(), signedType(longlongType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1451,8 +1455,8 @@ d <- [valueDef("_bittestandset64", builtinFunctionValueItem( {-  unsigned char(s
 d <- [valueDef("__debugbreak", builtinFunctionValueItem( {-  void(void) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __exception_code on line 803
--- Ignored _exception_code on line 804
+-- Ignored __exception_code on line 803: TODO: Ni type
+-- Ignored _exception_code on line 804: TODO: Ni type
 d <- [valueDef("__exception_info", builtinFunctionValueItem( {-  void * (void) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1465,21 +1469,21 @@ d <- [valueDef("__abnormal_termination", builtinFunctionValueItem( {-  signed in
 d <- [valueDef("_abnormal_termination", builtinFunctionValueItem( {-  signed int(void) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __GetExceptionInfo on line 809
+-- Ignored __GetExceptionInfo on line 809: needs custom type-checking logic
 d <- [valueDef("_InterlockedAnd8", builtinFunctionValueItem( {-  char(volatile char * , char) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(charType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("_InterlockedAnd16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedAnd on line 812
+-- Ignored _InterlockedAnd on line 812: TODO: Ni type
 d <- [valueDef("_InterlockedCompareExchange8", builtinFunctionValueItem( {-  char(volatile char * , char, char) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(charType())), builtinType(nilQualifier(), signedType(charType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("_InterlockedCompareExchange16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short, signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType())), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedCompareExchange on line 815
+-- Ignored _InterlockedCompareExchange on line 815: TODO: Ni type
 d <- [valueDef("_InterlockedCompareExchange64", builtinFunctionValueItem( {-  signed long long(volatile signed long long * , signed long long, signed long long) -}
     functionType(builtinType(nilQualifier(), signedType(longlongType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(longlongType()))), builtinType(nilQualifier(), signedType(longlongType())), builtinType(nilQualifier(), signedType(longlongType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1492,8 +1496,8 @@ d <- [valueDef("_InterlockedCompareExchangePointer_nf", builtinFunctionValueItem
 d <- [valueDef("_InterlockedDecrement16", builtinFunctionValueItem( {-  signed short(volatile signed short * ) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedDecrement on line 820
--- Ignored _InterlockedExchange on line 821
+-- Ignored _InterlockedDecrement on line 820: TODO: Ni type
+-- Ignored _InterlockedExchange on line 821: TODO: Ni type
 d <- [valueDef("_InterlockedExchange8", builtinFunctionValueItem( {-  char(volatile char * , char) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(charType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1506,7 +1510,7 @@ d <- [valueDef("_InterlockedExchangeAdd8", builtinFunctionValueItem( {-  char(vo
 d <- [valueDef("_InterlockedExchangeAdd16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedExchangeAdd on line 826
+-- Ignored _InterlockedExchangeAdd on line 826: TODO: Ni type
 d <- [valueDef("_InterlockedExchangePointer", builtinFunctionValueItem( {-  void * (volatile void *  * , void * ) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), voidType()))), pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1516,39 +1520,39 @@ d <- [valueDef("_InterlockedExchangeSub8", builtinFunctionValueItem( {-  char(vo
 d <- [valueDef("_InterlockedExchangeSub16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedExchangeSub on line 830
+-- Ignored _InterlockedExchangeSub on line 830: TODO: Ni type
 d <- [valueDef("_InterlockedIncrement16", builtinFunctionValueItem( {-  signed short(volatile signed short * ) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedIncrement on line 832
+-- Ignored _InterlockedIncrement on line 832: TODO: Ni type
 d <- [valueDef("_InterlockedOr8", builtinFunctionValueItem( {-  char(volatile char * , char) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(charType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("_InterlockedOr16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedOr on line 835
+-- Ignored _InterlockedOr on line 835: TODO: Ni type
 d <- [valueDef("_InterlockedXor8", builtinFunctionValueItem( {-  char(volatile char * , char) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(charType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("_InterlockedXor16", builtinFunctionValueItem( {-  signed short(volatile signed short * , signed short) -}
     functionType(builtinType(nilQualifier(), signedType(shortType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(shortType()))), builtinType(nilQualifier(), signedType(shortType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _InterlockedXor on line 838
--- Ignored _interlockedbittestandreset on line 839
+-- Ignored _InterlockedXor on line 838: TODO: Ni type
+-- Ignored _interlockedbittestandreset on line 839: TODO: Ni type
 d <- [valueDef("_interlockedbittestandreset64", builtinFunctionValueItem( {-  unsigned char(volatile signed long long * , signed long long) -}
     functionType(builtinType(nilQualifier(), unsignedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(longlongType()))), builtinType(nilQualifier(), signedType(longlongType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _interlockedbittestandreset_acq on line 841
--- Ignored _interlockedbittestandreset_nf on line 842
--- Ignored _interlockedbittestandreset_rel on line 843
--- Ignored _interlockedbittestandset on line 844
+-- Ignored _interlockedbittestandreset_acq on line 841: TODO: Ni type
+-- Ignored _interlockedbittestandreset_nf on line 842: TODO: Ni type
+-- Ignored _interlockedbittestandreset_rel on line 843: TODO: Ni type
+-- Ignored _interlockedbittestandset on line 844: TODO: Ni type
 d <- [valueDef("_interlockedbittestandset64", builtinFunctionValueItem( {-  unsigned char(volatile signed long long * , signed long long) -}
     functionType(builtinType(nilQualifier(), unsignedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(volatileQualifier(), nilQualifier()), signedType(longlongType()))), builtinType(nilQualifier(), signedType(longlongType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored _interlockedbittestandset_acq on line 846
--- Ignored _interlockedbittestandset_nf on line 847
--- Ignored _interlockedbittestandset_rel on line 848
+-- Ignored _interlockedbittestandset_acq on line 846: TODO: Ni type
+-- Ignored _interlockedbittestandset_nf on line 847: TODO: Ni type
+-- Ignored _interlockedbittestandset_rel on line 848: TODO: Ni type
 d <- [valueDef("__iso_volatile_load8", builtinFunctionValueItem( {-  char(const volatile char * ) -}
     functionType(builtinType(nilQualifier(), signedType(charType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), consQualifier(volatileQualifier(), nilQualifier())), signedType(charType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1627,14 +1631,14 @@ d <- [valueDef("_lrotr", builtinFunctionValueItem( {-  unsigned long(unsigned lo
 d <- [valueDef("_rotr64", builtinFunctionValueItem( {-  unsigned long long(unsigned long long, signed int) -}
     functionType(builtinType(nilQualifier(), unsignedType(longlongType())), protoFunctionType([builtinType(nilQualifier(), unsignedType(longlongType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __va_start on line 875
+-- Ignored __va_start on line 875: needs custom type-checking logic
 d <- [valueDef("__fastfail", builtinFunctionValueItem( {-  void(unsigned int) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), unsignedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_objc_memmove_collectable", builtinFunctionValueItem( {-  void * (void * , const void * , signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_annotation on line 1425
+-- Ignored __builtin_annotation on line 1425: needs custom type-checking logic
 d <- [valueDef("__builtin_assume", builtinFunctionValueItem( {-  void(_Bool) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), boolType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1668,9 +1672,9 @@ d <- [valueDef("__builtin_subcl", builtinFunctionValueItem( {-  unsigned long(co
 d <- [valueDef("__builtin_subcll", builtinFunctionValueItem( {-  unsigned long long(const unsigned long long, const unsigned long long, const unsigned long long, unsigned long long * ) -}
     functionType(builtinType(nilQualifier(), unsignedType(longlongType())), protoFunctionType([builtinType(consQualifier(constQualifier(), nilQualifier()), unsignedType(longlongType())), builtinType(consQualifier(constQualifier(), nilQualifier()), unsignedType(longlongType())), builtinType(consQualifier(constQualifier(), nilQualifier()), unsignedType(longlongType())), pointerType(nilQualifier(), builtinType(nilQualifier(), unsignedType(longlongType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_add_overflow on line 1443
--- Ignored __builtin_sub_overflow on line 1444
--- Ignored __builtin_mul_overflow on line 1445
+-- Ignored __builtin_add_overflow on line 1443: needs custom type-checking logic
+-- Ignored __builtin_sub_overflow on line 1444: needs custom type-checking logic
+-- Ignored __builtin_mul_overflow on line 1445: needs custom type-checking logic
 d <- [valueDef("__builtin_uadd_overflow", builtinFunctionValueItem( {-  _Bool(const unsigned int, const unsigned int, unsigned int * ) -}
     functionType(builtinType(nilQualifier(), boolType()), protoFunctionType([builtinType(consQualifier(constQualifier(), nilQualifier()), unsignedType(intType())), builtinType(consQualifier(constQualifier(), nilQualifier()), unsignedType(intType())), pointerType(nilQualifier(), builtinType(nilQualifier(), unsignedType(intType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1725,14 +1729,14 @@ d <- [valueDef("__builtin_smull_overflow", builtinFunctionValueItem( {-  _Bool(c
 d <- [valueDef("__builtin_smulll_overflow", builtinFunctionValueItem( {-  _Bool(const signed long long, const signed long long, signed long long * ) -}
     functionType(builtinType(nilQualifier(), boolType()), protoFunctionType([builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(longlongType())), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(longlongType())), pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(longlongType())))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_addressof on line 1466
--- Ignored __builtin_operator_new on line 1467
--- Ignored __builtin_operator_delete on line 1468
+-- Ignored __builtin_addressof on line 1466: C++ references
+-- Ignored __builtin_operator_new on line 1467: needs custom type-checking logic
+-- Ignored __builtin_operator_delete on line 1468: needs custom type-checking logic
 d <- [valueDef("__builtin_char_memchr", builtinFunctionValueItem( {-  char * (const char * , signed int, signed int) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_dump_struct on line 1470
--- Ignored __builtin_preserve_access_index on line 1471
+-- Ignored __builtin_dump_struct on line 1470: needs custom type-checking logic
+-- Ignored __builtin_preserve_access_index on line 1471: needs custom type-checking logic
 d <- [valueDef("__builtin___get_unsafe_stack_start", builtinFunctionValueItem( {-  void * (void) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1745,8 +1749,8 @@ d <- [valueDef("__builtin___get_unsafe_stack_top", builtinFunctionValueItem( {- 
 d <- [valueDef("__builtin___get_unsafe_stack_ptr", builtinFunctionValueItem( {-  void * (void) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_nontemporal_store on line 1480
--- Ignored __builtin_nontemporal_load on line 1481
+-- Ignored __builtin_nontemporal_store on line 1480: needs custom type-checking logic
+-- Ignored __builtin_nontemporal_load on line 1481: needs custom type-checking logic
 d <- [valueDef("__builtin_coro_resume", builtinFunctionValueItem( {-  void(void * ) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1789,36 +1793,36 @@ d <- [valueDef("__builtin_coro_suspend", builtinFunctionValueItem( {-  char(_Boo
 d <- [valueDef("__builtin_coro_param", builtinFunctionValueItem( {-  _Bool(void * , void * ) -}
     functionType(builtinType(nilQualifier(), boolType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored read_pipe on line 1503
--- Ignored write_pipe on line 1504
--- Ignored reserve_read_pipe on line 1506
--- Ignored reserve_write_pipe on line 1507
--- Ignored commit_write_pipe on line 1509
--- Ignored commit_read_pipe on line 1510
--- Ignored sub_group_reserve_read_pipe on line 1512
--- Ignored sub_group_reserve_write_pipe on line 1513
--- Ignored sub_group_commit_read_pipe on line 1515
--- Ignored sub_group_commit_write_pipe on line 1516
--- Ignored work_group_reserve_read_pipe on line 1518
--- Ignored work_group_reserve_write_pipe on line 1519
--- Ignored work_group_commit_read_pipe on line 1521
--- Ignored work_group_commit_write_pipe on line 1522
--- Ignored get_pipe_num_packets on line 1524
--- Ignored get_pipe_max_packets on line 1525
--- Ignored enqueue_kernel on line 1529
--- Ignored get_kernel_work_group_size on line 1530
--- Ignored get_kernel_preferred_work_group_size_multiple on line 1531
--- Ignored get_kernel_max_sub_group_size_for_ndrange on line 1532
--- Ignored get_kernel_sub_group_count_for_ndrange on line 1533
--- Ignored to_global on line 1538
--- Ignored to_local on line 1539
--- Ignored to_private on line 1540
--- Ignored __builtin_store_half on line 1543
--- Ignored __builtin_store_halff on line 1544
--- Ignored __builtin_load_half on line 1545
--- Ignored __builtin_load_halff on line 1546
--- Ignored __builtin_os_log_format_buffer_size on line 1549
--- Ignored __builtin_os_log_format on line 1550
+-- Ignored read_pipe on line 1503: needs custom type-checking logic
+-- Ignored write_pipe on line 1504: needs custom type-checking logic
+-- Ignored reserve_read_pipe on line 1506: needs custom type-checking logic
+-- Ignored reserve_write_pipe on line 1507: needs custom type-checking logic
+-- Ignored commit_write_pipe on line 1509: needs custom type-checking logic
+-- Ignored commit_read_pipe on line 1510: needs custom type-checking logic
+-- Ignored sub_group_reserve_read_pipe on line 1512: needs custom type-checking logic
+-- Ignored sub_group_reserve_write_pipe on line 1513: needs custom type-checking logic
+-- Ignored sub_group_commit_read_pipe on line 1515: needs custom type-checking logic
+-- Ignored sub_group_commit_write_pipe on line 1516: needs custom type-checking logic
+-- Ignored work_group_reserve_read_pipe on line 1518: needs custom type-checking logic
+-- Ignored work_group_reserve_write_pipe on line 1519: needs custom type-checking logic
+-- Ignored work_group_commit_read_pipe on line 1521: needs custom type-checking logic
+-- Ignored work_group_commit_write_pipe on line 1522: needs custom type-checking logic
+-- Ignored get_pipe_num_packets on line 1524: needs custom type-checking logic
+-- Ignored get_pipe_max_packets on line 1525: needs custom type-checking logic
+-- Ignored enqueue_kernel on line 1529: needs custom type-checking logic
+-- Ignored get_kernel_work_group_size on line 1530: needs custom type-checking logic
+-- Ignored get_kernel_preferred_work_group_size_multiple on line 1531: needs custom type-checking logic
+-- Ignored get_kernel_max_sub_group_size_for_ndrange on line 1532: needs custom type-checking logic
+-- Ignored get_kernel_sub_group_count_for_ndrange on line 1533: needs custom type-checking logic
+-- Ignored to_global on line 1538: needs custom type-checking logic
+-- Ignored to_local on line 1539: needs custom type-checking logic
+-- Ignored to_private on line 1540: needs custom type-checking logic
+-- Ignored __builtin_store_half on line 1543: TODO: h type
+-- Ignored __builtin_store_halff on line 1544: TODO: h type
+-- Ignored __builtin_load_half on line 1545: TODO: h type
+-- Ignored __builtin_load_halff on line 1546: TODO: h type
+-- Ignored __builtin_os_log_format_buffer_size on line 1549: needs custom type-checking logic
+-- Ignored __builtin_os_log_format on line 1550: needs custom type-checking logic
 d <- [valueDef("omp_is_initial_device", builtinFunctionValueItem( {-  signed int(void) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([], false), nilQualifier()),
     ordinaryFunctionHandler))];
@@ -1828,7 +1832,7 @@ d <- [valueDef("__xray_customevent", builtinFunctionValueItem( {-  void(const ch
 d <- [valueDef("__xray_typedevent", builtinFunctionValueItem( {-  void(signed int, const char * , signed int) -}
     functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), signedType(intType()))], false), nilQualifier()),
     ordinaryFunctionHandler))];
--- Ignored __builtin_ms_va_start on line 1560
--- Ignored __builtin_ms_va_end on line 1561
--- Ignored __builtin_ms_va_copy on line 1562
+-- Ignored __builtin_ms_va_start on line 1560: C++ references
+-- Ignored __builtin_ms_va_end on line 1561: C++ references
+-- Ignored __builtin_ms_va_copy on line 1562: C++ references
 }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -207,6 +207,12 @@ top::Expr ::= f::Name  a::Exprs
   forwards to callExpr(declRefExpr(@f), @a);
 }
 
+production unevaluatedFunctionHandler implements ReferenceCall
+top::Expr ::= f::Name  a::Exprs
+{
+  forwards to callWithUnevaluatedArgsExpr(declRefExpr(@f), @a);
+}
+
 production bindDirectCallExpr implements ReferenceCall
 top::Expr ::= f::Name a::Exprs result::Expr
 {
@@ -250,32 +256,32 @@ top::Expr ::= @f::Expr  a::Exprs
   top.freeVariables := f.freeVariables ++ removeDefsFromNames(f.defs, a.freeVariables);
   top.isLValue = false; -- C++ style references would change this
 
-  local subtype :: Either<Pair<Type FunctionType> [Message]> =
+  local fAsFuncType :: Either<Pair<Type FunctionType> [Message]> =
     case f.typerep.defaultFunctionArrayLvalueConversion of
     | pointerType(_, functionType(rt, sub, _)) -> left((^rt, ^sub))
     | errorType() -> right([]) -- error already raised.
     | _ -> right([errFromOrigin(f, "call expression is not function type (got " ++ show(80, f.typerep) ++ ")")])
     end;
   top.typerep =
-    case subtype of
+    case fAsFuncType of
     | left(l) -> l.fst
     | right(_) -> errorType()
     end;
   top.errors <-
-    case subtype of
+    case fAsFuncType of
      | left(_) -> a.argumentErrors
      | right(r) -> r
     end;
 
   a.expectedTypes =
-    case subtype of
+    case fAsFuncType of
     | left(pair(fst=_, snd=protoFunctionType(args, _))) -> args
     | _ -> []
     end;
   a.argumentPosition = 1;
   a.callExpr = f;
   a.callVariadic =
-    case subtype of
+    case fAsFuncType of
     | left(pair(fst=_, snd=protoFunctionType(_, variadic))) -> variadic
     | left(pair(fst=_, snd=noProtoFunctionType())) -> true
     | left(_) -> false
@@ -285,6 +291,59 @@ top::Expr ::= @f::Expr  a::Exprs
   a.env = addEnv(f.defs, f.env);
   a.controlStmtContext = top.controlStmtContext;
 }
+
+abstract production callWithUnevaluatedArgsExpr
+top::Expr ::= func::Expr  args::Exprs
+{
+  top.pp = parens(ppConcat([func.pp, parens(ppImplode(cat(comma(), space()), args.pps))]));
+  func.env = top.env;
+  func.controlStmtContext = top.controlStmtContext;
+  forwards to fromMaybe(defaultCallWithUnevaluatedArgsExpr, func.typerep.callWithUnevaluatedArgsProd)(func, @args);
+}
+abstract production defaultCallWithUnevaluatedArgsExpr implements Call
+top::Expr ::= @func::Expr  args::Exprs
+{
+  propagate errors, globalDecls, functionDecls, defs;
+  top.pp = parens(ppConcat([func.pp, parens(ppImplode(cat(comma(), space()), args.pps))]));
+  top.host = callExpr(func.host, args.host);
+  top.freeVariables := func.freeVariables ++ removeDefsFromNames(func.defs, args.freeVariables);
+
+  local funcAsFuncType :: Either<Pair<Type FunctionType> [Message]> =
+    case func.typerep.defaultFunctionArrayLvalueConversion of
+    | pointerType(_, functionType(returnType, sub, _)) -> left((^returnType, ^sub))
+    | errorType() -> right([]) -- error already raised.
+    | _ -> right([errFromOrigin(func, "call expression is not function type (got " ++ show(80, func.typerep) ++ ")")])
+    end;
+  top.typerep =
+    case funcAsFuncType of
+    | left(l) -> l.fst
+    | right(_) -> errorType()
+    end;
+  top.errors <-
+    case funcAsFuncType of
+     | left(_) -> args.argumentErrors
+     | right(r) -> r
+    end;
+
+  args.expectedTypes =
+    case funcAsFuncType of
+    | left(pair(fst=_, snd=protoFunctionType(args, _))) -> args
+    | _ -> []
+    end;
+  args.argumentPosition = 1;
+  args.callExpr = func;
+  args.callVariadic =
+    case funcAsFuncType of
+    | left(pair(fst=_, snd=protoFunctionType(_, variadic))) -> variadic
+    | left(pair(fst=_, snd=noProtoFunctionType())) -> true
+    | left(_) -> false
+    | _ -> true -- suppress errors
+    end;
+
+  args.env = addEnv(func.defs, func.env);
+  args.controlStmtContext = top.controlStmtContext;
+}
+
 abstract production memberCallExpr
 top::Expr ::= e::Expr  deref::Boolean  name::Name  a::Exprs
 {

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -207,10 +207,10 @@ top::Expr ::= f::Name  a::Exprs
   forwards to callExpr(declRefExpr(@f), @a);
 }
 
-production unevaluatedFunctionHandler implements ReferenceCall
+production unevaluatedBuiltinFunctionHandler implements ReferenceCall
 top::Expr ::= f::Name  a::Exprs
 {
-  forwards to callWithUnevaluatedArgsExpr(declRefExpr(@f), @a);
+  forwards to unevaluatedBuiltinFunctionCallExpr(@f, @a);
 }
 
 production bindDirectCallExpr implements ReferenceCall
@@ -292,27 +292,22 @@ top::Expr ::= @f::Expr  a::Exprs
   a.controlStmtContext = top.controlStmtContext;
 }
 
-abstract production callWithUnevaluatedArgsExpr
-top::Expr ::= func::Expr  args::Exprs
+abstract production unevaluatedBuiltinFunctionCallExpr
+top::Expr ::= func::Name  args::Exprs
 {
+  propagate controlStmtContext, defs, env, errors, functionDecls, globalDecls, host;
+  top.freeVariables := ^func :: args.freeVariables;
   top.pp = parens(ppConcat([func.pp, parens(ppImplode(cat(comma(), space()), args.pps))]));
-  func.env = top.env;
-  func.controlStmtContext = top.controlStmtContext;
-  forwards to fromMaybe(defaultCallWithUnevaluatedArgsExpr, func.typerep.callWithUnevaluatedArgsProd)(func, @args);
-}
-abstract production defaultCallWithUnevaluatedArgsExpr implements Call
-top::Expr ::= @func::Expr  args::Exprs
-{
-  propagate errors, globalDecls, functionDecls, defs;
-  top.pp = parens(ppConcat([func.pp, parens(ppImplode(cat(comma(), space()), args.pps))]));
-  top.host = callExpr(func.host, args.host);
-  top.freeVariables := func.freeVariables ++ removeDefsFromNames(func.defs, args.freeVariables);
+
+  production funcExpr :: Expr = declRefExpr(@func);
+  funcExpr.controlStmtContext = top.controlStmtContext;
+  funcExpr.env = top.env;
 
   local funcAsFuncType :: Either<Pair<Type FunctionType> [Message]> =
-    case func.typerep.defaultFunctionArrayLvalueConversion of
+    case func.valueItem.typerep.defaultFunctionArrayLvalueConversion of
     | pointerType(_, functionType(returnType, sub, _)) -> left((^returnType, ^sub))
     | errorType() -> right([]) -- error already raised.
-    | _ -> right([errFromOrigin(func, "call expression is not function type (got " ++ show(80, func.typerep) ++ ")")])
+    | _ -> right([errFromOrigin(func, "call expression is not function type (got " ++ show(80, func.valueItem.typerep) ++ ")")])
     end;
   top.typerep =
     case funcAsFuncType of
@@ -331,17 +326,14 @@ top::Expr ::= @func::Expr  args::Exprs
     | _ -> []
     end;
   args.argumentPosition = 1;
-  args.callExpr = func;
+  args.callExpr = funcExpr;
   args.callVariadic =
     case funcAsFuncType of
     | left(pair(fst=_, snd=protoFunctionType(_, variadic))) -> variadic
     | left(pair(fst=_, snd=noProtoFunctionType())) -> true
     | left(_) -> false
-    | _ -> true -- suppress errors
+    | right(_) -> true -- suppress errors
     end;
-
-  args.env = addEnv(func.defs, func.env);
-  args.controlStmtContext = top.controlStmtContext;
 }
 
 abstract production memberCallExpr

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Overload.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Overload.sv
@@ -16,8 +16,6 @@ top::Expr ::= @fn::Expr args::Exprs result::Expr
 
 synthesized attribute callProd::Maybe<Call> occurs on Type, ExtType;
 flowtype callProd {decorate} on Type, ExtType;
-synthesized attribute callWithUnevaluatedArgsProd::Maybe<Call> occurs on Type, ExtType;
-flowtype callWithUnevaluatedArgsProd {decorate} on Type, ExtType;
 
 dispatch MemberAccess = Expr ::= @e::Expr deref::Boolean name::Name;
 
@@ -401,7 +399,6 @@ top::Type ::=
 {
   top.arraySubscriptProd = nothing();
   top.callProd = nothing();
-  top.callWithUnevaluatedArgsProd = nothing();
   top.memberCallProd = nothing();
   top.memberProd = nothing();
   top.exprInitProd = nothing();
@@ -488,7 +485,6 @@ top::Type ::= q::Qualifiers  sub::ExtType
 {
   top.arraySubscriptProd = sub.arraySubscriptProd;
   top.callProd = sub.callProd;
-  top.callWithUnevaluatedArgsProd = sub.callWithUnevaluatedArgsProd;
   top.memberCallProd = sub.memberCallProd;
   top.memberProd = sub.memberProd;
   top.exprInitProd = sub.exprInitProd;
@@ -568,7 +564,6 @@ top::ExtType ::=
 {
   top.arraySubscriptProd = nothing();
   top.callProd = nothing();
-  top.callWithUnevaluatedArgsProd = nothing();
   top.memberCallProd = nothing();
   top.memberProd = nothing();
   top.exprInitProd = nothing();

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Overload.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Overload.sv
@@ -16,6 +16,8 @@ top::Expr ::= @fn::Expr args::Exprs result::Expr
 
 synthesized attribute callProd::Maybe<Call> occurs on Type, ExtType;
 flowtype callProd {decorate} on Type, ExtType;
+synthesized attribute callWithUnevaluatedArgsProd::Maybe<Call> occurs on Type, ExtType;
+flowtype callWithUnevaluatedArgsProd {decorate} on Type, ExtType;
 
 dispatch MemberAccess = Expr ::= @e::Expr deref::Boolean name::Name;
 
@@ -399,6 +401,7 @@ top::Type ::=
 {
   top.arraySubscriptProd = nothing();
   top.callProd = nothing();
+  top.callWithUnevaluatedArgsProd = nothing();
   top.memberCallProd = nothing();
   top.memberProd = nothing();
   top.exprInitProd = nothing();
@@ -485,6 +488,7 @@ top::Type ::= q::Qualifiers  sub::ExtType
 {
   top.arraySubscriptProd = sub.arraySubscriptProd;
   top.callProd = sub.callProd;
+  top.callWithUnevaluatedArgsProd = sub.callWithUnevaluatedArgsProd;
   top.memberCallProd = sub.memberCallProd;
   top.memberProd = sub.memberProd;
   top.exprInitProd = sub.exprInitProd;
@@ -564,6 +568,7 @@ top::ExtType ::=
 {
   top.arraySubscriptProd = nothing();
   top.callProd = nothing();
+  top.callWithUnevaluatedArgsProd = nothing();
   top.memberCallProd = nothing();
   top.memberProd = nothing();
   top.exprInitProd = nothing();

--- a/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
+++ b/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
@@ -89,13 +89,19 @@ concrete productions top::Builtins
 tracked nonterminal Builtin with ignoredBuiltins;
 
 concrete production builtinFunction
-top::Builtin ::= BUILTIN '(' id::Identifier ',' '"' t::Types dots::MaybeDots '"' ',' '"' x::IgnoredStuff '"' ')'
+top::Builtin ::= BUILTIN '(' id::Identifier ',' '"' t::Types dots::MaybeDots '"' ',' '"' attrs::IgnoredStuff '"' ')'
 {
   top.ignoredBuiltins := 
-    if t.ignoreMe || indexOf("t", x.lexeme) != -1 || indexOf("u", x.lexeme) != -1 then
-      ["-- Ignored " ++ id.lexeme ++ " on line " ++ toString(id.location.line)]
-      --[]
-    else ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    ordinaryFunctionHandler))];" ];
+    if not(null(t.ignoreReasons)) then
+      ["-- Ignored " ++ id.lexeme ++ " on line " ++ toString(id.location.line) ++ ": " ++ implode(", ", uniq(sort(t.ignoreReasons)))]
+    else if indexOf("t", attrs.lexeme) != -1 then
+      --  t -> signature is meaningless, use custom typechecking
+      ["-- Ignored " ++ id.lexeme ++ " on line " ++ toString(id.location.line) ++ ": needs custom type-checking logic"]
+    else if indexOf("u", attrs.lexeme) != -1 then
+      --  u -> arguments are not evaluated for their side-effects
+      ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    unevaluatedFunctionHandler))];" ]
+    else
+      ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    ordinaryFunctionHandler))];" ];
   
   local debugprint :: String =
     debugging:show(80, debugging:cat(sig.a:lpp, sig.a:rpp));
@@ -135,11 +141,11 @@ top::Builtin ::= LIBBUILTIN_NotProcessed
   top.ignoredBuiltins := []; -- We know about this. Just the others.
 }
 
-monoid attribute ignoreMe :: Boolean with false, ||;
+monoid attribute ignoreReasons :: [String] with [], ++;
 synthesized attribute signature :: [a:Type];
 
-tracked nonterminal Types with ignoreMe, signature;
-propagate ignoreMe on Types;
+tracked nonterminal Types with ignoreReasons, signature;
+propagate ignoreReasons on Types;
 
 concrete productions top::Types
 | h::Type  t::Types
@@ -147,8 +153,8 @@ concrete productions top::Types
 |
   { top.signature = []; }
 
-tracked nonterminal Type with ignoreMe, typerep;
-propagate ignoreMe on Type;
+tracked nonterminal Type with ignoreReasons, typerep;
+propagate ignoreReasons on Type;
 
 synthesized attribute typerep :: a:Type;
 
@@ -167,8 +173,8 @@ fun addpointers a:Type ::= count::Integer  t::a:Type =
 
 monoid attribute issigned :: Boolean with true, &&;
 
-tracked nonterminal TypePrefixes with ignoreMe, issigned;
-propagate ignoreMe, issigned on TypePrefixes;
+tracked nonterminal TypePrefixes with ignoreReasons, issigned;
+propagate ignoreReasons, issigned on TypePrefixes;
 
 concrete production consTypePrefixes
 top::TypePrefixes ::= h::TypePrefix  t::TypePrefixes
@@ -180,19 +186,19 @@ top::TypePrefixes ::=
 monoid attribute qualifiers :: a:Qualifiers with a:nilQualifier(), a:qualifierCat;
 monoid attribute pointercount :: Integer with 0, +;
 
-tracked nonterminal TypeSuffixes with ignoreMe, qualifiers, pointercount;
-propagate ignoreMe, qualifiers, pointercount on TypeSuffixes;
+tracked nonterminal TypeSuffixes with ignoreReasons, qualifiers, pointercount;
+propagate ignoreReasons, qualifiers, pointercount on TypeSuffixes;
 
 concrete productions top::TypeSuffixes
 | h::TypeSuffix  t::TypeSuffixes  {}
 | {}
 
-tracked nonterminal TypePrefix with ignoreMe, issigned;
+tracked nonterminal TypePrefix with ignoreReasons, issigned;
 
 aspect default production
 top::TypePrefix ::=
 {
-  propagate ignoreMe, issigned;
+  propagate ignoreReasons, issigned;
 }
 
 concrete productions top::TypePrefix
@@ -201,9 +207,9 @@ concrete productions top::TypePrefix
 --| 'LLL' {}
 | 'S' {}
 | 'U' { top.issigned := false;}
-| 'I' { }-- top.ignoreMe = true; } -- maybe ignore all of these? -- TODO: for now, allowing it!
+| 'I' { }-- top.ignoreReasons = true; } -- maybe ignore all of these? -- TODO: for now, allowing it!
 
-tracked nonterminal TypeSpecifier with ignoreMe, specifier, size, givenSign, givenDomain;
+tracked nonterminal TypeSpecifier with ignoreReasons, specifier, size, givenSign, givenDomain;
 
 synthesized attribute specifier :: (a:Type ::= a:Qualifiers);
 synthesized attribute size :: Integer;  -- Size on X86_64 (which is all we care about for vector intrinsics, for now...) 
@@ -215,7 +221,7 @@ propagate givenSign, givenDomain on TypeSpecifier excluding complexTypeSpec;
 aspect default production
 top::TypeSpecifier ::=
 {
-  top.ignoreMe := false;
+  top.ignoreReasons := [];
 }
 
 concrete productions top::TypeSpecifier
@@ -228,20 +234,20 @@ concrete productions top::TypeSpecifier
 | 'L' 'i' {-long-} { top.specifier = a:builtinType(_, top.givenSign(a:longType())); top.size = 8; }
 | 'O' 'i' {-long long-} { top.specifier = a:builtinType(_, top.givenSign(a:longlongType())); top.size = 8; }
 | 'LL' 'i' {-long long-} { top.specifier = a:builtinType(_, top.givenSign(a:longlongType())); top.size = 8; }
-| 'N' 'i' {-whatever this is-} { top.ignoreMe := true; } -- TODO
+| 'N' 'i' {-whatever this is-} { top.ignoreReasons := ["TODO: Ni type"]; } -- TODO
 | 'LLL' 'i' {-int128-} { top.specifier = a:builtinType(_, top.givenSign(a:int128Type())); top.size = 16; }
 
 | 'Z' 'i' {-int32-} { top.specifier = a:builtinType(_, top.givenSign(a:intType())); top.size = 4; }
 | 'W' 'i' {-int64-} { top.specifier = a:builtinType(_, top.givenSign(a:longlongType())); top.size = 8; }
 
-| 'h' {-half-float/fp16-} { top.ignoreMe := true; } -- TODO
+| 'h' {-half-float/fp16-} { top.ignoreReasons := ["TODO: h type"]; } -- TODO
 | 'f' {-float-} { top.specifier = a:builtinType(_, top.givenDomain(a:floatType())); top.size = 4; }
 | 'd' {-double-} { top.specifier = a:builtinType(_, top.givenDomain(a:doubleType())); top.size = 8; }
 | 'L' 'd' {-long double-} { top.specifier = a:builtinType(_, top.givenDomain(a:longdoubleType())); top.size = 16; }
-| 'LL' 'd' {-fp128-} { top.ignoreMe := true; } -- TODO
+| 'LL' 'd' {-fp128-} { top.ignoreReasons := ["TODO: LLd type"]; } -- TODO
 
-| 'F' {-ObjC crap-} { top.ignoreMe := true;  } -- Ignore anything with this spec
-| 'P' {-FILE-} { top.ignoreMe := true; } -- dunno what to do with this?
+| 'F' {-ObjC crap-} { top.ignoreReasons := ["TODO: F type"];  } -- Ignore anything with this spec
+| 'P' {-FILE-} { top.ignoreReasons := ["TODO: P type"]; } -- dunno what to do with this?
 | 'z' {-size_t-} { top.specifier = a:builtinType(_, top.givenSign(a:intType())); top.size = 8; } -- TODO: do better?
 | 'a' {-valist-} { top.specifier = a:builtinType(_, a:voidType()); } -- TODO
 | 'A' {-valist?pointer maybe?-} { top.specifier = a:pointerType(_, a:builtinType(a:nilQualifier(), a:voidType())); top.size = 8; }-- TODO ALSO: underscore in wrong spot
@@ -254,7 +260,7 @@ concrete productions top::TypeSpecifier
   { top.specifier = \ qs::a:Qualifiers -> a:vectorType(more.specifier(qs), top.size); top.size = toInteger(n.lexeme) * more.size; }
 
 
-nonterminal Languages with ignoreMe;
+nonterminal Languages with ignoreReasons;
 
 concrete productions top::Languages
 | 'ALL_LANGUAGES' {}
@@ -264,17 +270,17 @@ concrete productions top::Languages
 | 'OCLC20_LANG' {}
 | 'OMP_LANG' {}
 
-tracked nonterminal TypeSuffix with ignoreMe, qualifiers, pointercount;
+tracked nonterminal TypeSuffix with ignoreReasons, qualifiers, pointercount;
 
 aspect default production
 top::TypeSuffix ::=
 {
-  propagate ignoreMe, qualifiers, pointercount;
+  propagate ignoreReasons, qualifiers, pointercount;
 }
 
 concrete productions top::TypeSuffix
 | '*' {-pointer-} { top.pointercount := 1; }
-| '&' {-C++-} { top.ignoreMe := true; } -- ignore these
+| '&' {-C++-} { top.ignoreReasons := ["C++ references"]; } -- ignore these
 | 'C' {-const-} { top.qualifiers := a:consQualifier(a:constQualifier(), a:nilQualifier()); }
 | 'D' {-volatile-} { top.qualifiers := a:consQualifier(a:volatileQualifier(), a:nilQualifier()); }
 

--- a/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
+++ b/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
@@ -99,7 +99,7 @@ top::Builtin ::= BUILTIN '(' id::Identifier ',' '"' t::Types dots::MaybeDots '"'
       ["-- Ignored " ++ id.lexeme ++ " on line " ++ toString(id.location.line) ++ ": needs custom type-checking logic"]
     else if indexOf("u", attrs.lexeme) != -1 then
       --  u -> arguments are not evaluated for their side-effects
-      ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    unevaluatedFunctionHandler))];" ]
+      ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    unevaluatedBuiltinFunctionHandler))];" ]
     else
       ["d <- [valueDef(\"" ++ id.lexeme ++ "\", builtinFunctionValueItem( {- " ++ debugprint ++ " -}\n    " ++ reflect(new(sig)).translation ++ ",\n    ordinaryFunctionHandler))];" ];
   

--- a/testing/expected-results/positive
+++ b/testing/expected-results/positive
@@ -80,7 +80,7 @@
 - NO ERROR    tests/gcc/compile/positive/pr46723.c
 - NO ERROR    tests/gcc/compile/positive/pr47281.c
 - NO ERROR    tests/gcc/compile/positive/pr47370.c
-- ERROR       tests/gcc/compile/positive/pr47411.c
+- NO ERROR    tests/gcc/compile/positive/pr47411.c
 - NO ERROR    tests/gcc/compile/positive/pr47677.c
 - NO ERROR    tests/gcc/compile/positive/pr47725.c
 - NO ERROR    tests/gcc/compile/positive/pr47743.c
@@ -104,7 +104,7 @@
 - ERROR       tests/gcc/compile/positive/pr51071.c
 - NO ERROR    tests/gcc/compile/positive/pr51245.c
 - ERROR       tests/gcc/compile/positive/pr51692.c
-- ERROR       tests/gcc/compile/positive/pr51760.c
+- NO ERROR    tests/gcc/compile/positive/pr51760.c
 - NO ERROR    tests/gcc/compile/positive/pr51801.c
 - ERROR       tests/gcc/compile/positive/pr51949.c
 - NO ERROR    tests/gcc/compile/positive/pr52170.c
@@ -769,6 +769,6 @@
 
 
 Summary:
-  67 errored
-  701 did not error
+  65 errored
+  703 did not error
 

--- a/testing/runTests
+++ b/testing/runTests
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 shopt -s extglob globstar
+cd "$(dirname "${BASH_SOURCE[@]}")"
 
 export LANG=C  # Disable localization to force deterministic glob ordering
 


### PR DESCRIPTION
Depends on https://github.com/melt-umn/silver/pull/862.

@krame505 , do you remember what the `indexOf("t", x.lexeme) != -1 || indexOf("u", x.lexeme) != -1` condition was about?