### PR TITLE
Makes va_list a BuiltinType, allowing it to be used in builtin functions.

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/builtins/GeneratedBuiltins.sv
@@ -948,14 +948,14 @@ d <- [valueDef("__builtin_rotateright64", builtinFunctionValueItem( {-  unsigned
 -- Ignored __builtin___CFStringMakeConstantString on line 469: TODO: F type
 -- Ignored __builtin___NSStringMakeConstantString on line 470: TODO: F type
 -- Ignored __builtin_va_start on line 471: needs custom type-checking logic
-d <- [valueDef("__builtin_va_end", builtinFunctionValueItem( {-  void(void * ) -}
-    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
+d <- [valueDef("__builtin_va_end", builtinFunctionValueItem( {-  void(__builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin_va_copy", builtinFunctionValueItem( {-  void(void * , void * ) -}
-    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], false), nilQualifier()),
+d <- [valueDef("__builtin_va_copy", builtinFunctionValueItem( {-  void(__builtin_va_list, __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), vaListType()), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin_stdarg_start", builtinFunctionValueItem( {-  void(void * , ...) -}
-    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), voidType()))], true), nilQualifier()),
+d <- [valueDef("__builtin_stdarg_start", builtinFunctionValueItem( {-  void(__builtin_va_list, ...) -}
+    functionType(builtinType(nilQualifier(), voidType()), protoFunctionType([builtinType(nilQualifier(), vaListType())], true), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_assume_aligned", builtinFunctionValueItem( {-  void * (const void * , signed int, ...) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), voidType())), builtinType(nilQualifier(), signedType(intType()))], true), nilQualifier()),
@@ -1102,11 +1102,11 @@ d <- [valueDef("__builtin_eh_return_data_regno", builtinFunctionValueItem( {-  s
 d <- [valueDef("__builtin_snprintf", builtinFunctionValueItem( {-  signed int(char * , signed int, const char * , ...) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], true), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin_vsprintf", builtinFunctionValueItem( {-  signed int(char * , const char * , void) -}
-    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
+d <- [valueDef("__builtin_vsprintf", builtinFunctionValueItem( {-  signed int(char * , const char * , __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin_vsnprintf", builtinFunctionValueItem( {-  signed int(char * , signed int, const char * , void) -}
-    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
+d <- [valueDef("__builtin_vsnprintf", builtinFunctionValueItem( {-  signed int(char * , signed int, const char * , __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_thread_pointer", builtinFunctionValueItem( {-  void * (void) -}
     functionType(pointerType(nilQualifier(), builtinType(nilQualifier(), voidType())), protoFunctionType([], false), nilQualifier()),
@@ -1184,19 +1184,19 @@ d <- [valueDef("__builtin___snprintf_chk", builtinFunctionValueItem( {-  signed 
 d <- [valueDef("__builtin___sprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, const char * , ...) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], true), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin___vsnprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, signed int, const char * , void) -}
-    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
+d <- [valueDef("__builtin___vsnprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, signed int, const char * , __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
-d <- [valueDef("__builtin___vsprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, const char * , void) -}
-    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
+d <- [valueDef("__builtin___vsprintf_chk", builtinFunctionValueItem( {-  signed int(char * , signed int, signed int, const char * , __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([pointerType(nilQualifier(), builtinType(nilQualifier(), signedType(charType()))), builtinType(nilQualifier(), signedType(intType())), builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
 -- Ignored __builtin___fprintf_chk on line 558: TODO: P type
 d <- [valueDef("__builtin___printf_chk", builtinFunctionValueItem( {-  signed int(signed int, const char * , ...) -}
     functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType())))], true), nilQualifier()),
     ordinaryFunctionHandler))];
 -- Ignored __builtin___vfprintf_chk on line 560: TODO: P type
-d <- [valueDef("__builtin___vprintf_chk", builtinFunctionValueItem( {-  signed int(signed int, const char * , void) -}
-    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), voidType())], false), nilQualifier()),
+d <- [valueDef("__builtin___vprintf_chk", builtinFunctionValueItem( {-  signed int(signed int, const char * , __builtin_va_list) -}
+    functionType(builtinType(nilQualifier(), signedType(intType())), protoFunctionType([builtinType(nilQualifier(), signedType(intType())), pointerType(nilQualifier(), builtinType(consQualifier(constQualifier(), nilQualifier()), signedType(charType()))), builtinType(nilQualifier(), vaListType())], false), nilQualifier()),
     ordinaryFunctionHandler))];
 d <- [valueDef("__builtin_unpredictable", builtinFunctionValueItem( {-  signed long(signed long) -}
     functionType(builtinType(nilQualifier(), signedType(longType())), protoFunctionType([builtinType(nilQualifier(), signedType(longType()))], false), nilQualifier()),

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeExprs.sv
@@ -380,16 +380,6 @@ top::BaseTypeExpr ::= q::Qualifiers  wrapped::TypeName
   top.typeModifier = baseTypeExpr();
   q.typeToQualify = top.typerep;
 }
-{-- GCC builtin type -}
-abstract production vaListTypeExpr
-top::BaseTypeExpr ::=
-{
-  propagate host, errors, globalDecls, functionDecls, hostDecls, defs, freeVariables, controlStmtContext;
-  top.typerep = pointerType(nilQualifier(),
-    builtinType(nilQualifier(), voidType())); -- TODO this should be a special type, not void
-  top.pp = text("__builtin_va_list");
-  top.typeModifier = baseTypeExpr();
-}
 {-- GCC typeof type -}
 abstract production typeofTypeExpr
 top::BaseTypeExpr ::= q::Qualifiers  e::ExprOrTypeName

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeOps.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypeOps.sv
@@ -203,6 +203,7 @@ fun builtinCompatible Boolean ::= a::BuiltinType  b::BuiltinType  allowSubtypes:
   case a, b of
   | voidType(), voidType() -> true
   | boolType(), boolType() -> true
+  | vaListType(), vaListType() -> true
   | realType(r1), realType(r2) -> realTypeEq(r1, r2)
   | complexType(r1), complexType(r2) -> realTypeEq(r1, r2)
   | imaginaryType(r1), imaginaryType(r2) -> realTypeEq(r1, r2)
@@ -340,6 +341,7 @@ Boolean ::= lval::Type  rval::Type
             compatibleTypes(^b1, ^b2, true, true) && s1 == s2 -- TODO: no idea
 -- the left operand has type atomic, qualified, or unqualified _Bool, and the right is a pointer.
     | builtinType(_, boolType()), _ when rval.defaultFunctionArrayLvalueConversion matches pointerType(_, _) -> true
+    | builtinType(_, vaListType()), builtinType(_, vaListType()) -> true
     | _, _ -> false
     end;
 }

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypesBuiltin.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/TypesBuiltin.sv
@@ -35,6 +35,17 @@ top::BuiltinType ::=
   top.isArithmeticType = true;
 }
 
+abstract production vaListType
+top::BuiltinType ::=
+{
+  top.pp = text("__builtin_va_list");
+  top.mangledName = "va_list";
+  top.integerPromotionsBuiltin = top;
+  top.defaultArgumentPromotionsBuiltin = top;
+  top.isIntegerType = false;
+  top.isArithmeticType = false;
+}
+
 {-- any real type -}
 abstract production realType
 top::BuiltinType ::= rt::RealType

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Declarations.sv
@@ -58,7 +58,7 @@ concrete productions top::TypeQualifier_c
 concrete productions top::TypeSpecifier_c
 | '__builtin_va_list'
     { top.preTypeSpecifiers = [];
-      top.realTypeSpecifiers = [ast:vaListTypeExpr()]; }
+      top.realTypeSpecifiers = [ast:builtinTypeExpr(top.givenQualifiers, ast:vaListType())]; }
 | '__signed__'
     { top.realTypeSpecifiers = [];
       top.preTypeSpecifiers = ["signed"]; }

--- a/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Pragma.sv
+++ b/grammars/edu.umn.cs.melt.ableC/concretesyntax/gcc_exts/Pragma.sv
@@ -35,3 +35,6 @@ concrete productions top::Stmt_c
 | '#' 'pragma' omp::OMPFor_t
     layout { Spaces_t }
     { top.ast = ast:txtStmt("#pragma " ++ omp.lexeme); }
+| '#' 'pragma' gcc::GCC_t
+    layout { Spaces_t }
+    { top.ast = ast:txtStmt("#pragma " ++ gcc.lexeme); }

--- a/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
+++ b/grammars/edu.umn.cs.melt.ableC/tools/builtins/Processor.sv
@@ -249,8 +249,23 @@ concrete productions top::TypeSpecifier
 | 'F' {-ObjC crap-} { top.ignoreReasons := ["TODO: F type"];  } -- Ignore anything with this spec
 | 'P' {-FILE-} { top.ignoreReasons := ["TODO: P type"]; } -- dunno what to do with this?
 | 'z' {-size_t-} { top.specifier = a:builtinType(_, top.givenSign(a:intType())); top.size = 8; } -- TODO: do better?
-| 'a' {-valist-} { top.specifier = a:builtinType(_, a:voidType()); } -- TODO
-| 'A' {-valist?pointer maybe?-} { top.specifier = a:pointerType(_, a:builtinType(a:nilQualifier(), a:voidType())); top.size = 8; }-- TODO ALSO: underscore in wrong spot
+{- Builtins.def says:
+ -
+ -    a -> __builtin_va_list
+ -    A -> "reference" to __builtin_va_list
+ -
+ - They both seem to be used in ways where, if they were ordinary functions,
+ - they'd both be the same type:
+ -
+ -    BUILTIN(__builtin_va_start, "vA.", "nt")
+ -    BUILTIN(__builtin___vsprintf_chk, "ic*izcC*a", "FP:3:")
+ -
+ - The difference seems to be that va_start is _intended_ to operate on a
+ - locally-declared va_list, rather than one passed as an argument, but gcc
+ - lets you pass a va_list accepted as an argument to __builtin_va_start too...
+ -}
+| 'a' {-valist-}              { top.specifier = a:builtinType(_, a:vaListType()); top.size = 8; }
+| 'A' {-valist "reference" -} { top.specifier = a:builtinType(_, a:vaListType()); top.size = 8; }
 (complexTypeSpec)
 | 'X'  more::TypeSpecifier {-_Complex-} { more.givenSign = a:complexIntegerType;
                                           more.givenDomain = a:complexType;


### PR DESCRIPTION
This gets us down to 1 failing test on NixOS, failing for unrelated reasons (`testing/tests/gcc/link/positive/builtin-ctype-2.c`). I think this counts as a fix for #221.