### PR TITLE
Build downstream extensions in a single workspace to allow for sharing of intermediate artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,9 @@ melt.trynode('ableC') {
 
     melt.clearGenerated()
 
+    // Delete old extension checkouts in this workspace
+    sh "rm -rf ${EXTS_BASE}/*"
+
     withEnv(newenv) {
       sh './build --mwda'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ melt.setProperties(silverBase: true)
 melt.trynode('ableC') {
   def ABLEC_BASE = env.WORKSPACE
   def SILVER_BASE = silver.resolveSilver()
+  def EXTS_BASE = env.WORKSPACE + "/extensions"
   def newenv = silver.getSilverEnv(SILVER_BASE)
 
   stage ("Build") {
@@ -67,7 +68,7 @@ melt.trynode('ableC') {
      */
 
     def tasks = [:]
-    def newargs = [SILVER_BASE: SILVER_BASE, ABLEC_BASE: ABLEC_BASE]
+    def newargs = [SILVER_BASE: SILVER_BASE, ABLEC_BASE: ABLEC_BASE, EXTS_BASE: EXTS_BASE]
     tasks << extensions.collectEntries { t ->
       [(t): { melt.buildProject("/melt-umn/${t}", newargs) }]
     }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+# This Makefile only exists to for use by recursive make, to avoid unnecessary recompilation.
+
+ableC.jar: $(shell find grammars/ -name *.sv -print0 | xargs -0)
+	./build

--- a/extension.mk
+++ b/extension.mk
@@ -144,25 +144,33 @@ include depends.mk
 generated lib:
 	mkdir -p $@
 
+# Locking is used to ensure that multiple parallel make invocations in the same workspace
+# don't lead to race conditions causing a dependency to be built more than once.
+ifeq ($(MAKELEVEL),0)
+LOCK=flock $(dir $@)
+else
+LOCK=
+endif
+
 $(ABLEC_JAR): $(shell find $(ABLEC_BASE)/grammars/ -name *.sv -print0 | xargs -0)
-	cd $(ABLEC_BASE) && ./build $(SVFLAGS)
+	$(LOCK) $(MAKE) -C $(ABLEC_BASE) ableC.jar
 
 $(EXTS_BASE)/%.jar:
-	$(MAKE) -C $(dir $@) $(notdir $@)
+	$(LOCK) $(MAKE) -C $(dir $@) $(notdir $@)
 
 ifdef USE_CUSTOM_SILVER
 # Note that $(DEP_JARS) are order-only dependencies, to avoid expensive rebuilds.
 # If dependency extension syntax changes, this may require `make depclean` to be reflected.
 silver-compiler.jar: $(wildcard grammars/*/artifacts/silver_compiler/*.sv) | $(DEP_JARS) generated
-	silver -o $@ $(SVFLAGS) $(EXT_GRAMMAR):artifacts:silver_compiler
+	$(LOCK) silver -o $@ $(SVFLAGS) $(EXT_GRAMMAR):artifacts:silver_compiler
 endif
 
 $(ARTIFACT_JAR): $(GRAMMAR_SOURCES) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
-	$(SILVER) -o $@ $(SVFLAGS) $(EXT_GRAMMAR)
+	$(LOCK) $(SILVER) -o $@ $(SVFLAGS) $(EXT_GRAMMAR)
 
 compiler.jar: $(ARTIFACT_JAR) $(GRAMMAR_SOURCES) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
 # TODO: Shouldn't need to use the extended Silver here?
-	$(SILVER) -o $@ -I $(ARTIFACT_JAR) $(SVFLAGS) $(EXT_GRAMMAR):artifacts:compiler
+	$(LOCK) $(SILVER) -o $@ -I $(ARTIFACT_JAR) $(SVFLAGS) $(EXT_GRAMMAR):artifacts:compiler
 
 mda.test: $(ARTIFACT_JAR) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
 # TODO: Shouldn't need to use the extended Silver here?


### PR DESCRIPTION
This means we are no longer rebuilding all extension dependencies from scratch in every downstream extension. This nearly cuts the integration build time in half, from 40 minutes to 23 minutes, and should help with scaling as we add more extensions going forward.

The `extensions.mk` build file now uses `flock` so that multiple builds can safely run in parallel in the same workspace, without trying to concurrently rebuild the same artifact.

This also required some changes in the jenkins-lib repo.  This means ableC is currently failing on develop but will be fixed by this PR.