### PR TITLE
Fix to locking for extension make invocations

### DIFF
--- a/extension.mk
+++ b/extension.mk
@@ -146,31 +146,49 @@ generated lib:
 
 # Locking is used to ensure that multiple parallel make invocations in the same workspace
 # don't lead to race conditions causing a dependency to be built more than once.
-ifeq ($(MAKELEVEL),0)
 LOCK=flock $(dir $@)
-else
-LOCK=
-endif
 
 $(ABLEC_JAR): $(shell find $(ABLEC_BASE)/grammars/ -name *.sv -print0 | xargs -0)
+ifeq ($(MAKELEVEL),0)
 	$(LOCK) $(MAKE) -C $(ABLEC_BASE) ableC.jar
+else
+	echo "$@ should not be built from recursive make invocation!"
+	exit 1
+endif
 
 $(EXTS_BASE)/%.jar:
+ifeq ($(MAKELEVEL),0)
 	$(LOCK) $(MAKE) -C $(dir $@) $(notdir $@)
+else
+	echo "$@ should not be built from recursive make invocation!"
+	exit 1
+endif
 
 ifdef USE_CUSTOM_SILVER
 # Note that $(DEP_JARS) are order-only dependencies, to avoid expensive rebuilds.
 # If dependency extension syntax changes, this may require `make depclean` to be reflected.
-silver-compiler.jar: $(wildcard grammars/*/artifacts/silver_compiler/*.sv) | $(DEP_JARS) generated
-	$(LOCK) silver -o $@ $(SVFLAGS) $(EXT_GRAMMAR):artifacts:silver_compiler
+$(SV_COMPILER_JAR): $(wildcard grammars/*/artifacts/silver_compiler/*.sv) | $(DEP_JARS) generated
+  ifeq ($(MAKELEVEL),0)
+	$(LOCK) $(MAKE) $@
+  else
+	silver -o $@ $(SVFLAGS) $(EXT_GRAMMAR):artifacts:silver_compiler
+  endif
 endif
 
 $(ARTIFACT_JAR): $(GRAMMAR_SOURCES) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
-	$(LOCK) $(SILVER) -o $@ $(SVFLAGS) $(EXT_GRAMMAR)
+ifeq ($(MAKELEVEL),0)
+	$(LOCK) $(MAKE) $@
+else
+	$(SILVER) -o $@ $(SVFLAGS) $(EXT_GRAMMAR)
+endif
 
 compiler.jar: $(ARTIFACT_JAR) $(GRAMMAR_SOURCES) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
+ifeq ($(MAKELEVEL),0)
+	$(LOCK) $(MAKE) $@
+else
 # TODO: Shouldn't need to use the extended Silver here?
-	$(LOCK) $(SILVER) -o $@ -I $(ARTIFACT_JAR) $(SVFLAGS) $(EXT_GRAMMAR):artifacts:compiler
+	$(SILVER) -o $@ -I $(ARTIFACT_JAR) $(SVFLAGS) $(EXT_GRAMMAR):artifacts:compiler
+endif
 
 mda.test: $(ARTIFACT_JAR) $(DEP_JARS) $(SV_COMPILER_JAR) | generated
 # TODO: Shouldn't need to use the extended Silver here?
@@ -257,7 +275,7 @@ THIS_EXT=$(EXTS_BASE)/$(EXT_NAME)
 # Print the definitions that should be added to the Makefile of any extension depending on this one.
 print_depends:
 ifdef USE_CUSTOM_SILVER
-	@echo '$(THIS_EXT)/silver-compiler.jar: | $(DEP_JARS)'
+	@echo '$(THIS_EXT)/$(SV_COMPILER_JAR): | $(DEP_JARS)'
 endif
 	@echo '$(THIS_EXT)/$(ARTIFACT_JAR): $(addprefix $(THIS_EXT)/,$(GRAMMAR_SOURCES) $(SV_COMPILER_JAR)) $(DEP_JARS)'
 ifneq ($(LIB_NAME),)


### PR DESCRIPTION
This ensures that we avoid invoking silver again to build an extension artifact after aquiring the lock, if the artifact is up-to-date.  This fixes a race condtion where no-op silver builds for up-to-date grammars were still modifying the jars, causing concurrent builds depending on those jars to fail.