### PR TITLE
Decay array types in binding declarations

### DIFF
--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/env/ValueItem.sv
@@ -81,7 +81,7 @@ top::ValueItem ::= s::Decorated ParameterDecl
 abstract production autoValueItem
 top::ValueItem ::= e::Decorated Expr
 {
-  top.typerep = e.typerep;
+  top.typerep = e.typerep.defaultFunctionArrayLvalueConversion;
   top.isItemValue = true;
 }
 

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Decls.sv
@@ -228,15 +228,16 @@ top::Decl ::= n::Name  e::Expr
 {
   propagate env, errors, globalDecls, functionDecls, defs, freeVariables;
   top.pp = pp"auto ${n.pp} = ${e.pp};";
+  local hostTy::Type = e.typerep.defaultFunctionArrayLvalueConversion.canonicalType.host;
   top.host =
     variableDecls(
       nilStorageClass(),
       nilAttribute(),
-      e.typerep.host.baseTypeExpr,
+      hostTy.baseTypeExpr,
       consDeclarator(
         declarator(
           ^n,
-          e.typerep.host.typeModifierExpr,
+          hostTy.typeModifierExpr,
           nilAttribute(),
           justInitializer(exprInitializer(e.host))),
         nilDeclarator()));

--- a/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
+++ b/grammars/edu.umn.cs.melt.ableC/abstractsyntax/host/Expr.sv
@@ -39,11 +39,11 @@ top::Expr ::=
     else variableDecls(
       nilStorageClass(),
       nilAttribute(),
-      top.typerep.host.baseTypeExpr,
+      top.typerep.defaultFunctionArrayLvalueConversion.canonicalType.host.baseTypeExpr,
       consDeclarator(
         declarator(
           top.bindName,
-          top.typerep.host.typeModifierExpr,
+          top.typerep.defaultFunctionArrayLvalueConversion.canonicalType.host.typeModifierExpr,
           nilAttribute(),
           justInitializer(exprInitializer(top.host))),
         nilDeclarator()));


### PR DESCRIPTION
If one has an expression of type `char []` that is bound in an auto declaration, then the newly declared variable should have type `char *` and not `char []`.  The following is illegal, as a variable is not a valid array initializer:
```c
char x[] = "abcd";
char y[] = x;
```